### PR TITLE
DNS Reverse Forward Look Up 

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -164,6 +164,28 @@ This ensures efficient scanning but means some valid deep subdomains may be miss
 
 	subenumCmd.AddCommand(subenumbruteCmd)
 
+	reverseforwardCmd := &cobra.Command{
+		Use:   "reverseforward",
+		Short: "Reverse and forward lookup a given domain",
+		Long:  `Reverse and forward lookup a given domain`,
+		Run: func(cmd *cobra.Command, args []string) {
+			domain, err := cmd.Flags().GetString("domain")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report := dns.GetReverseForwardDNSLookup(domain)
+			a.OutputSignal.Content = report
+		},
+	}
+
+	reverseforwardCmd.Flags().String("domain", "", "Domain to get reverse and forward lookup for")
+
+	_ = reverseforwardCmd.MarkFlagRequired("domain")
+
+	subenumCmd.AddCommand(reverseforwardCmd)
+
 	takeoverCmd := &cobra.Command{
 		Use:   "takeover",
 		Short: "Detect domain takeovers given a list of targets",

--- a/fern/definition/dnsreverseforward.yml
+++ b/fern/definition/dnsreverseforward.yml
@@ -1,0 +1,10 @@
+types:
+  LookUpDetails:
+    properties:
+      ip: string
+      dnsPtrs: optional<list<string>>
+  DnsReverseForwardReport:
+    properties:
+      domain: string
+      lookUps: optional<list<LookUpDetails>>
+      errors: optional<list<string>>

--- a/generated/go/types.go
+++ b/generated/go/types.go
@@ -145,6 +145,91 @@ func (d *DnsRecordsReport) String() string {
 	return fmt.Sprintf("%#v", d)
 }
 
+type DnsReverseForwardReport struct {
+	Domain  string           `json:"domain" url:"domain"`
+	LookUps []*LookUpDetails `json:"lookUps,omitempty" url:"lookUps,omitempty"`
+	Errors  []string         `json:"errors,omitempty" url:"errors,omitempty"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (d *DnsReverseForwardReport) GetExtraProperties() map[string]interface{} {
+	return d.extraProperties
+}
+
+func (d *DnsReverseForwardReport) UnmarshalJSON(data []byte) error {
+	type unmarshaler DnsReverseForwardReport
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*d = DnsReverseForwardReport(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *d)
+	if err != nil {
+		return err
+	}
+	d.extraProperties = extraProperties
+
+	d._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (d *DnsReverseForwardReport) String() string {
+	if len(d._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(d._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(d); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", d)
+}
+
+type LookUpDetails struct {
+	Ip      string   `json:"ip" url:"ip"`
+	DnsPtrs []string `json:"dnsPtrs,omitempty" url:"dnsPtrs,omitempty"`
+
+	extraProperties map[string]interface{}
+	_rawJSON        json.RawMessage
+}
+
+func (l *LookUpDetails) GetExtraProperties() map[string]interface{} {
+	return l.extraProperties
+}
+
+func (l *LookUpDetails) UnmarshalJSON(data []byte) error {
+	type unmarshaler LookUpDetails
+	var value unmarshaler
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	*l = LookUpDetails(value)
+
+	extraProperties, err := core.ExtractExtraProperties(data, *l)
+	if err != nil {
+		return err
+	}
+	l.extraProperties = extraProperties
+
+	l._rawJSON = json.RawMessage(data)
+	return nil
+}
+
+func (l *LookUpDetails) String() string {
+	if len(l._rawJSON) > 0 {
+		if value, err := core.StringifyJSON(l._rawJSON); err == nil {
+			return value
+		}
+	}
+	if value, err := core.StringifyJSON(l); err == nil {
+		return value
+	}
+	return fmt.Sprintf("%#v", l)
+}
+
 type DnsSubenumReport struct {
 	Domain          string         `json:"domain" url:"domain"`
 	EnumerationType DnsSubenumType `json:"enumerationType" url:"enumerationType"`

--- a/internal/dns/reverseforward.go
+++ b/internal/dns/reverseforward.go
@@ -1,0 +1,41 @@
+package dns
+
+import (
+	"net"
+
+	osintscan "github.com/Method-Security/osintscan/generated/go"
+)
+
+// ReverseLookup then ForwardLookup
+func GetReverseForwardDNSLookup(fqdn string) osintscan.DnsReverseForwardReport {
+	report := osintscan.DnsReverseForwardReport{
+		Domain: fqdn,
+	}
+	errors := []string{}
+
+	// Resolve the IP addresses for the given FQDN
+	ips, err := net.LookupIP(fqdn)
+	if err != nil {
+		errors = append(errors, err.Error())
+		report.Errors = errors
+		return report
+	}
+
+	lookUps := []*osintscan.LookUpDetails{}
+	for _, ip := range ips {
+		// Perform a reverse lookup (PTR record)
+		names, err := net.LookupAddr(ip.String())
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+
+		// Store resolved hostnames per IP
+		lookUps = append(lookUps, &osintscan.LookUpDetails{
+			Ip:      ip.String(),
+			DnsPtrs: names,
+		})
+	}
+	report.LookUps = lookUps
+	report.Errors = errors
+	return report
+}


### PR DESCRIPTION
## New Tool

Reverse forward look up to enumerate more DNS records + link FQDNs to IP Addresses

## Note
If no PTR Record Exists likely because many cloud providers (AWS, GCP, Azure) and CDNs (Cloudflare, Akamai, Fastly) do not set PTR records