### PR TITLE
Allow custom dns resolver

### DIFF
--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -146,7 +146,13 @@ This ensures efficient scanning but means some valid deep subdomains may be miss
 				return
 			}
 
-			report, err := subenum.GetDomainSubdomainsBrute(cmd.Context(), domain, allSubdomains, parallelThreads, recursiveDepth, timeout)
+			dnsServerAddress, err := cmd.Flags().GetString("dnsServerAddress")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			report, err := subenum.GetDomainSubdomainsBrute(cmd.Context(), domain, allSubdomains, parallelThreads, recursiveDepth, timeout, dnsServerAddress)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -161,6 +167,7 @@ This ensures efficient scanning but means some valid deep subdomains may be miss
 	subenumbruteCmd.Flags().Int("threads", 20, "Number of parallel threads")
 	subenumbruteCmd.Flags().Int("maxdepth", 3, "Maximum recursion depth")
 	subenumbruteCmd.Flags().Int("timeout", 0, "Maximum time of enumeration (Minutes)")
+	subenumbruteCmd.Flags().String("dnsServerAddress", "", "IP address of DNS server to use")
 
 	_ = subenumbruteCmd.MarkFlagRequired("domain")
 

--- a/cmd/dns.go
+++ b/cmd/dns.go
@@ -167,7 +167,7 @@ This ensures efficient scanning but means some valid deep subdomains may be miss
 	subenumbruteCmd.Flags().Int("threads", 20, "Number of parallel threads")
 	subenumbruteCmd.Flags().Int("maxdepth", 3, "Maximum recursion depth")
 	subenumbruteCmd.Flags().Int("timeout", 0, "Maximum time of enumeration (Minutes)")
-	subenumbruteCmd.Flags().String("dnsServerAddress", "", "IP address of DNS server to use")
+	subenumbruteCmd.Flags().String("dnsServerAddress", "", "IP address + port of DNS server to use")
 
 	_ = subenumbruteCmd.MarkFlagRequired("domain")
 

--- a/docs/docs/dns.md
+++ b/docs/docs/dns.md
@@ -120,13 +120,14 @@ Usage:
   osintscan dns subenum brute [flags]
 
 Flags:
-      --domain string       Domain to get subdomains for
-      --file strings        List of files containing subdomains to enumerate
-  -h, --help                help for brute
-      --maxdepth int        Maximum recursion depth (default 3)
-      --subdomain strings   List of subdomains to enumerate
-      --threads int         Number of parallel threads (default 20)
-      --timeout int         Maximum time of enumeration (Minutes)
+      --dnsServerAddress string   IP address + port of DNS server to use
+      --domain string             Domain to get subdomains for
+      --file strings              List of files containing subdomains to enumerate
+  -h, --help                      help for brute
+      --maxdepth int              Maximum recursion depth (default 3)
+      --subdomain strings         List of subdomains to enumerate
+      --threads int               Number of parallel threads (default 20)
+      --timeout int               Maximum time of enumeration (Minutes)
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")

--- a/internal/dns/subenum/brute.go
+++ b/internal/dns/subenum/brute.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	osintscan "github.com/Method-Security/osintscan/generated/go"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // GetDomainSubdomainsBrute queries subfinder for all subdomains for a given domain. It returns a SubdomainsEnumReport struct containing
@@ -54,6 +55,7 @@ func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolve
 }
 
 func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, dnsServerAddress string) ([]string, error) {
+	log := svc1log.FromContext(ctx)
 	subdomains := []string{}
 	subdomainsSet := make(map[string]struct{}) // To track unique valid subdomains
 	subdomainsMutex := &sync.Mutex{}
@@ -68,8 +70,10 @@ func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []stri
 
 	var resolver *net.Resolver
 	if dnsServerAddress == "" {
+		log.Info("Using system default DNS resolver")
 		resolver = &net.Resolver{}
 	} else {
+		log.Info("Using custom DNS server address", svc1log.SafeParam("dnsServerAddress", dnsServerAddress))
 		resolver = &net.Resolver{
 			PreferGo: true,
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {

--- a/internal/dns/subenum/brute.go
+++ b/internal/dns/subenum/brute.go
@@ -14,14 +14,14 @@ import (
 
 // GetDomainSubdomainsBrute queries subfinder for all subdomains for a given domain. It returns a SubdomainsEnumReport struct containing
 // all subdomains and any errors that occurred.
-func GetDomainSubdomainsBrute(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int) (osintscan.DnsSubenumReport, error) {
+func GetDomainSubdomainsBrute(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, dnsServerAddress string) (osintscan.DnsSubenumReport, error) {
 	report := osintscan.DnsSubenumReport{
 		Domain:          domain,
 		EnumerationType: osintscan.DnsSubenumTypeBrute,
 	}
 	errors := []string{}
 
-	subdomains, err := getSubdomainsBrute(ctx, domain, subdomainList, parallelThreads, recursiveDepth, timeout)
+	subdomains, err := getSubdomainsBrute(ctx, domain, subdomainList, parallelThreads, recursiveDepth, timeout, dnsServerAddress)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
@@ -53,7 +53,7 @@ func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolve
 	return nil, nil
 }
 
-func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int) ([]string, error) {
+func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, dnsServerAddress string) ([]string, error) {
 	subdomains := []string{}
 	subdomainsSet := make(map[string]struct{}) // To track unique valid subdomains
 	subdomainsMutex := &sync.Mutex{}
@@ -66,10 +66,23 @@ func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []stri
 		defer cancel()
 	}
 
-	resolver := net.Resolver{}
+	var resolver *net.Resolver
+	if dnsServerAddress == "" {
+		resolver = &net.Resolver{}
+	} else {
+		resolver = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{
+					Timeout: time.Second * 10,
+				}
+				return d.DialContext(ctx, "udp", dnsServerAddress)
+			},
+		}
+	}
 
 	// First iteration - test all base subdomains
-	wildcardDNS, err := detectWildcardDNS(ctx, domain, &resolver)
+	wildcardDNS, err := detectWildcardDNS(ctx, domain, resolver)
 	if err != nil {
 		return []string{}, err
 	}
@@ -80,7 +93,7 @@ func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []stri
 	}
 
 	basePermutations := generatePermutations([]string{domain}, subdomainList)
-	validBaseSubdomains := testPermutations(ctx, basePermutations, &resolver, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains)
+	validBaseSubdomains := testPermutations(ctx, basePermutations, resolver, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains)
 
 	// For each subsequent depth, only build on valid subdomains from previous iteration
 	currentDepthSubdomains := validBaseSubdomains
@@ -91,8 +104,11 @@ func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []stri
 
 		validSubdomains := []string{}
 		for _, subdomain := range currentDepthSubdomains {
-			wildcardDNS, err := detectWildcardDNS(ctx, subdomain, &resolver)
-			if err != nil || wildcardDNS != nil {
+			wildcardDNS, err := detectWildcardDNS(ctx, subdomain, resolver)
+			if err != nil {
+				continue
+			}
+			if wildcardDNS != nil {
 				domain = *wildcardDNS
 				subdomains = append(subdomains, domain)
 				continue
@@ -101,7 +117,7 @@ func getSubdomainsBrute(ctx context.Context, domain string, subdomainList []stri
 		}
 
 		newPermutations := generatePermutations(validSubdomains, subdomainList)
-		currentDepthSubdomains = testPermutations(ctx, newPermutations, &resolver, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains)
+		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolver, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains)
 	}
 
 	return subdomains, nil


### PR DESCRIPTION
Allows specifying the address of a DNS server for the brute force subdomain enumeration command. Addresses are of the form `IP:port`.

Tested by running against `208.67.222.222:53` (OpenDNS) and confirming that this worked, while `208.67.222.222:52` (incorrect port) resulted in the CLI hanging.