### PR TITLE
Fern Update

### DIFF
--- a/fern/definition/pentest/dns/takeover.yml
+++ b/fern/definition/pentest/dns/takeover.yml
@@ -16,7 +16,7 @@ types:
       fingerprints: list<DomainTakeoverFingerprint>
       successfulOnly: boolean
       httpsOnly: boolean
-      verifyTLS: boolean
+      verifyTls: boolean
       timeout: integer
   # Report
   HostingService:


### PR DESCRIPTION
### TL;DR

Renamed `verifyTLS` parameter to `verifyTls` in the DNS takeover configuration.

### What changed?

Changed the parameter name from `verifyTLS` to `verifyTls` in the DNS takeover configuration file, ensuring consistent camelCase naming convention throughout the codebase.

### How to test?

1. Verify that any code referencing this parameter has been updated to use the new name
2. Ensure that DNS takeover functionality works correctly with the renamed parameter
3. Check that API documentation reflects this parameter name change

### Why make this change?

This change standardizes the naming convention to follow consistent camelCase formatting. The mixed-case "TLS" was inconsistent with our style guidelines, where acronyms after the first position in a camelCase identifier should use lowercase.