### PR TITLE
ReverseForward > ForwardReverse 

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -84,10 +84,10 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Add command to 'dns' command
 	discoverDNSCmd.AddCommand(discoverDNSRecordsCmd)
 
-	discoverDNSReverseForwardCmd := &cobra.Command{
-		Use:   "reverseforward",
-		Short: "Perform reverse and forward DNS lookups",
-		Long:  `Perform both reverse and forward DNS lookups for the specified domain to identify associated IPs and hostnames.`,
+	discoverDNSForwardReverseCmd := &cobra.Command{
+		Use:   "forwardreverse",
+		Short: "Perform forward and reverse DNS lookups",
+		Long:  `Perform both forward and reverse DNS lookups for the specified domain to identify associated IPs and hostnames.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			domain, err := cmd.Flags().GetString("domain")
 			if err != nil {
@@ -95,19 +95,19 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			report := dns.GetReverseForwardDNSLookup(domain)
+			report := dns.GetForwardReverseDNSLookup(domain)
 			a.OutputSignal.Content = report
 		},
 	}
 
 	// Target Flags
-	discoverDNSReverseForwardCmd.Flags().String("domain", "", "The domain name to perform reverse and forward lookups on")
+	discoverDNSForwardReverseCmd.Flags().String("domain", "", "The domain name to perform forward and reverse lookups on")
 
 	// Mark Required Flags
-	_ = discoverDNSReverseForwardCmd.MarkFlagRequired("domain")
+	_ = discoverDNSForwardReverseCmd.MarkFlagRequired("domain")
 
 	// Add command to 'dns' command
-	discoverDNSCmd.AddCommand(discoverDNSReverseForwardCmd)
+	discoverDNSCmd.AddCommand(discoverDNSForwardReverseCmd)
 
 	discoverDNSSubdomainCmd := &cobra.Command{
 		Use:   "subdomain",

--- a/fern/definition/discover/dns/reverseforward.yml
+++ b/fern/definition/discover/dns/reverseforward.yml
@@ -3,7 +3,7 @@ types:
     properties:
       ip: string
       dnsPtrs: optional<list<string>>
-  DiscoverDnsReverseForwardReport:
+  DiscoverDnsForwardReverseReport:
     properties:
       domain: string
       lookUps: optional<list<LookUpDetails>>

--- a/internal/discover/dns/reverseforward.go
+++ b/internal/discover/dns/reverseforward.go
@@ -6,10 +6,10 @@ import (
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
 )
 
-// GetReverseForwardDNSLookup performs both forward (A/AAAA) and reverse (PTR) DNS lookups for a given FQDN.
+// GetForwardReverseDNSLookup performs both forward (A/AAAA) and reverse (PTR) DNS lookups for a given FQDN.
 // Returns a report containing all resolved IPs and their associated hostnames, along with any errors encountered.
-func GetReverseForwardDNSLookup(fqdn string) dnsfern.DiscoverDnsReverseForwardReport {
-	report := dnsfern.DiscoverDnsReverseForwardReport{
+func GetForwardReverseDNSLookup(fqdn string) dnsfern.DiscoverDnsForwardReverseReport {
+	report := dnsfern.DiscoverDnsForwardReverseReport{
 		Domain: fqdn,
 	}
 	errors := []string{}


### PR DESCRIPTION
### TL;DR

Renamed DNS lookup command from "reverseforward" to "forwardreverse" to better reflect the order of operations and ontology tool name.

### What changed?

- Renamed the DNS lookup command from `reverseforward` to `forwardreverse` in the CLI
- Updated the command description to match the new name
- Renamed the associated function from `GetReverseForwardDNSLookup` to `GetForwardReverseDNSLookup`
- Updated the report type name from `DiscoverDnsReverseForwardReport` to `DiscoverDnsForwardReverseReport`
- Updated all related flag descriptions and documentation

### How to test?

1. Run the new command: `osintscan discover dns forwardreverse --domain example.com`
2. Verify that the command performs forward and reverse DNS lookups correctly
3. Confirm that the output report structure is maintained with the renamed type

### Why make this change?

The command name now accurately reflects the order of operations performed by the function. The DNS lookup process first performs forward lookups (domain to IP) and then reverse lookups (IP to hostname), so "forwardreverse" is a more logical and intuitive name than "reverseforward".