### PR TITLE
Line up tool config with Cobra CLI inputs

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -188,7 +188,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			subdomainlistFiles, err := cmd.Flags().GetStringSlice("files")
+			subdomainlistFiles, err := cmd.Flags().GetStringSlice("subdomain-lists")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -234,12 +234,13 @@ func (a *OsintScan) InitDiscoverCommand() {
 			config := dnsfern.DiscoverDnsSubdomainConfig{
 				DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeActive)),
 				Active: &dnsfern.DiscoverDnsSubdomainActiveConfig{
-					Domain:      domain,
-					Subdomains:  allSubdomains,
-					Threads:     &threads,
-					MaxDepth:    &maxDepth,
-					Timeout:     &timeout,
-					DnsResolver: &dnsResolver,
+					Domain:         domain,
+					Subdomains:     allSubdomains,
+					SubdomainLists: subdomainlistFiles,
+					Threads:        &threads,
+					MaxDepth:       &maxDepth,
+					Timeout:        &timeout,
+					DnsResolver:    &dnsResolver,
 				},
 			}
 
@@ -257,7 +258,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Config Flags
 	discoverDNSSubdomainActiveCmd.Flags().StringSlice("subdomains", []string{}, "A list of subdomain names to test during discovery")
-	discoverDNSSubdomainActiveCmd.Flags().StringSlice("files", []string{}, "File paths containing lists of subdomains to use for discovery")
+	discoverDNSSubdomainActiveCmd.Flags().StringSlice("subdomain-lists", []string{}, "File paths containing lists of subdomains to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("threads", 20, "Number of parallel threads to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("max-depth", 3, "Maximum recursion depth for subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 0, "Maximum time (in minutes) to spend on subdomain discovery")

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -53,7 +53,7 @@ func (a *OsintScan) InitPentestCommand() {
 			}
 
 			// Config
-			fingerprintsPath, err := cmd.Flags().GetString("fingerprint-files")
+			fingerprintsPath, err := cmd.Flags().GetString("fingerprints-file")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -86,9 +86,9 @@ func (a *OsintScan) InitPentestCommand() {
 				return
 			}
 
-			config := getDNSTakeoverConfig(allTargets, fileTargets, fingerprints, successfulOnly, verifyTLS, timeout)
+			config := getDNSTakeoverConfig(allTargets, fileTargets, fingerprintsPath, successfulOnly, verifyTLS, timeout)
 
-			report, err := takeover.DetectDomainTakeover(cmd.Context(), config)
+			report, err := takeover.DetectDomainTakeover(cmd.Context(), config, fingerprints)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -101,7 +101,7 @@ func (a *OsintScan) InitPentestCommand() {
 	pentestDNSTakeoverCmd.Flags().StringSlice("targets", []string{}, "A list of URLs or domains to analyze for takeover vulnerabilities")
 	pentestDNSTakeoverCmd.Flags().StringSlice("target-files", []string{}, "File paths containing lists of targets to analyze for takeover vulnerabilities")
 	// Config Flags
-	pentestDNSTakeoverCmd.Flags().String("fingerprint-files", "configs/pentest/dns/takeover/fingerprints.json", "Path to the JSON file containing service fingerprints for takeover detection")
+	pentestDNSTakeoverCmd.Flags().String("fingerprints-file", "configs/pentest/dns/takeover/fingerprints.json", "Path to the JSON file containing service fingerprints for takeover detection")
 	pentestDNSTakeoverCmd.Flags().Bool("successful-only", false, "Show only confirmed successful takeovers in the results")
 	pentestDNSTakeoverCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests during takeover analysis")
 	pentestDNSTakeoverCmd.Flags().Int("timeout", 30, "Timeout in seconds for each takeover check request")
@@ -112,13 +112,13 @@ func (a *OsintScan) InitPentestCommand() {
 	a.RootCmd.AddCommand(pentestCmd)
 }
 
-func getDNSTakeoverConfig(targets []string, targetFiles []string, fingerprints []*dnsfern.DomainTakeoverFingerprint, successfulOnly bool, verifyTLS bool, timeout int) dnsfern.PentestDomainTakeoverConfig {
+func getDNSTakeoverConfig(targets []string, targetFiles []string, fingerprintsFile string, successfulOnly bool, verifyTLS bool, timeout int) dnsfern.PentestDomainTakeoverConfig {
 	config := dnsfern.PentestDomainTakeoverConfig{
-		Targets:        targets,
-		TargetFiles:    targetFiles,
-		Fingerprints:   fingerprints,
-		SuccessfulOnly: successfulOnly,
-		VerifyTls:      verifyTLS,
+		Targets:          targets,
+		TargetFiles:      targetFiles,
+		FingerprintsFile: &fingerprintsFile,
+		SuccessfulOnly:   successfulOnly,
+		VerifyTls:        verifyTLS,
 	}
 
 	if timeout >= 0 {

--- a/fern/definition/pentest/dns/takeover.yml
+++ b/fern/definition/pentest/dns/takeover.yml
@@ -33,10 +33,10 @@ types:
     properties:
       targets: list<string>
       targetFiles: optional<list<string>>
+      fingerprintsFile: optional<string>
       successfulOnly: boolean
       verifyTls: boolean
       timeout: integer
-      fingerprints: list<DomainTakeoverFingerprint>
   PentestDomainTakeoverResult:
     properties:
       domainTakeovers: list<DomainTakeover>

--- a/fern/definition/pentest/dns/takeover.yml
+++ b/fern/definition/pentest/dns/takeover.yml
@@ -15,6 +15,7 @@ types:
     properties:
       name: string
       vulnerable: boolean
+      fingerprint: optional<string>
   DomainTakeoverResponse:
     properties:
       statusCode: optional<integer>

--- a/internal/pentest/dns/takeover/takeover.go
+++ b/internal/pentest/dns/takeover/takeover.go
@@ -11,7 +11,7 @@ import (
 
 // DetectDomainTakeover checks a list of targets for potential subdomain takeover vulnerabilities.
 // Returns a report containing the results for each target and any errors encountered.
-func DetectDomainTakeover(ctx context.Context, config dnsfern.PentestDomainTakeoverConfig) (*dnsfern.PentestDomainTakeoverReport, error) {
+func DetectDomainTakeover(ctx context.Context, config dnsfern.PentestDomainTakeoverConfig, fingerprints []*dnsfern.DomainTakeoverFingerprint) (*dnsfern.PentestDomainTakeoverReport, error) {
 	errs := []string{}
 
 	// Create HTTP client
@@ -38,7 +38,7 @@ func DetectDomainTakeover(ctx context.Context, config dnsfern.PentestDomainTakeo
 			}
 
 			// Assess target for takeover
-			response, serviceResults, successful := assessTarget(url, httpClient, config.Fingerprints, cname, returnsNXDomain, config.SuccessfulOnly)
+			response, serviceResults, successful := assessTarget(url, httpClient, fingerprints, cname, returnsNXDomain, config.SuccessfulOnly)
 			if !config.SuccessfulOnly || successful {
 				takeoverResult := dnsfern.DomainTakeover{
 					Target:          url,

--- a/internal/pentest/dns/takeover/takeover.go
+++ b/internal/pentest/dns/takeover/takeover.go
@@ -119,8 +119,9 @@ func analyzeResponse(fingerprints []*dnsfern.DomainTakeoverFingerprint, cname st
 			continue
 		}
 		hostingServiceResult := dnsfern.HostingService{
-			Name:       fp.Service,
-			Vulnerable: isVulnerable,
+			Name:        fp.Service,
+			Vulnerable:  isVulnerable,
+			Fingerprint: &fp.Fingerprint,
 		}
 		serviceResults = append(serviceResults, &hostingServiceResult)
 		successful = successful || isVulnerable


### PR DESCRIPTION
### TL;DR

Renamed CLI flag parameters for better clarity and fixed subdomain list handling in the DNS takeover detection functionality.

### What changed?

- Renamed the `--files` flag to `--subdomain-lists` in the discover command for better clarity
- Renamed the `--fingerprint-files` flag to `--fingerprints-file` in the pentest command
- Updated the `PentestDomainTakeoverConfig` structure to include `FingerprintsFile` as an optional string parameter instead of embedding fingerprints directly
- Modified the `DetectDomainTakeover` function to accept fingerprints as a separate parameter
- Added subdomain lists to the active discovery configuration

### How to test?

1. Run the discover command with the new flag name:
   ```
   ./dnsfern discover dns subdomain active --subdomain-lists path/to/subdomains.txt
   ```

2. Run the pentest command with the renamed fingerprints flag:
   ```
   ./dnsfern pentest dns takeover --fingerprints-file path/to/fingerprints.json
   ```

3. Verify that subdomain lists are properly loaded during active discovery

### Why make this change?

The flag names were updated to be more descriptive and consistent with their actual functionality. The separation of fingerprints file path from the actual fingerprints data in the configuration improves the API design by allowing the file to be loaded separately from the configuration setup. This change also ensures that subdomain lists are properly passed to the active discovery configuration.