### PR TITLE
Move subdomain wordlist function to appropriate package

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -219,7 +219,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 				}
 				wordlistSizeEnum = &wordlistSizeEnumValue
 
-				filePath := utils.GetDiscoverDNSSubdomainActiveWordlistPath(wordlistSize)
+				filePath := subdomain.GetDiscoverDNSSubdomainActiveWordlistPath(wordlistSize)
 				if filePath != "" {
 					wordlistSubdomains, err = utils.GetEntriesFromFiles([]string{filePath})
 					if err != nil {

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -58,9 +58,6 @@ func (a *OsintScan) InitPentestCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			if fingerprintsPath == "" {
-				fingerprintsPath = "/opt/method/osintscan/var/conf/pentest/dns/takeover/fingerprints.json"
-			}
 			fingerprints, err := takeover.RetrieveFingerprints(fingerprintsPath)
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -104,7 +101,7 @@ func (a *OsintScan) InitPentestCommand() {
 	pentestDNSTakeoverCmd.Flags().StringSlice("targets", []string{}, "A list of URLs or domains to analyze for takeover vulnerabilities")
 	pentestDNSTakeoverCmd.Flags().StringSlice("target-files", []string{}, "File paths containing lists of targets to analyze for takeover vulnerabilities")
 	// Config Flags
-	pentestDNSTakeoverCmd.Flags().String("fingerprints-file", "", "Path to the JSON file containing service fingerprints for takeover detection")
+	pentestDNSTakeoverCmd.Flags().String("fingerprints-file", "/opt/method/osintscan/var/conf/pentest/dns/takeover/fingerprints.json", "Path to the JSON file containing service fingerprints for takeover detection")
 	pentestDNSTakeoverCmd.Flags().Bool("successful-only", false, "Show only confirmed successful takeovers in the results")
 	pentestDNSTakeoverCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests during takeover analysis")
 	pentestDNSTakeoverCmd.Flags().Int("timeout", 30, "Timeout in seconds for each takeover check request")

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -185,3 +185,15 @@ func generateRandomSubdomain(domain string) (string, error) {
 
 	return fmt.Sprintf("%s.%s", string(randomString), domain), nil
 }
+
+// GetDiscoverDNSSubdomainActiveWordlistPath returns the file path for a given wordlist size
+func GetDiscoverDNSSubdomainActiveWordlistPath(wordlistSize string) string {
+	wordlistPaths := map[string]string{
+		"TINY":   "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-100.txt",
+		"SMALL":  "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-5000.txt",
+		"MEDIUM": "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-20000.txt",
+		"LARGE":  "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-110000.txt",
+	}
+
+	return wordlistPaths[wordlistSize]
+}

--- a/utils/files.go
+++ b/utils/files.go
@@ -30,15 +30,3 @@ func GetEntriesFromFiles(paths []string) ([]string, error) {
 	}
 	return entries, nil
 }
-
-// GetDiscoverDNSSubdomainActiveWordlistPath returns the file path for a given wordlist size
-func GetDiscoverDNSSubdomainActiveWordlistPath(wordlistSize string) string {
-	wordlistPaths := map[string]string{
-		"TINY":   "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-100.txt",
-		"SMALL":  "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-5000.txt",
-		"MEDIUM": "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-20000.txt",
-		"LARGE":  "/opt/method/osintscan/var/conf/discover/dns/subdomain/wordlist-110000.txt",
-	}
-
-	return wordlistPaths[wordlistSize]
-}


### PR DESCRIPTION
### TL;DR

Moved DNS subdomain wordlist path function to a more appropriate package and set default fingerprints file path in the CLI flag.

### What changed?

- Moved `GetDiscoverDNSSubdomainActiveWordlistPath` function from `utils` package to `internal/discover/dns/subdomain` package where it's more logically placed
- Set the default value for the `--fingerprints-file` flag in the pentest DNS takeover command instead of checking for an empty value in the code
- Updated references to the moved function in the discover command

### How to test?

1. Run the discover command with subdomain enumeration to verify the wordlist paths still work correctly:
   ```
   osintscan discover dns subdomain --targets example.com --wordlist-size SMALL
   ```

2. Run the pentest DNS takeover command without specifying a fingerprints file to verify it uses the default path:
   ```
   osintscan pentest dns takeover --targets example.com
   ```

### Why make this change?

This refactoring improves code organization by placing the DNS subdomain wordlist path function in the appropriate package alongside related functionality. It also follows best practices by setting default flag values at the CLI definition level rather than checking for empty values in the command execution code.