### PR TITLE
Fix DNS Takeover Fern

### DIFF
--- a/fern/definition/pentest/dns/takeover.yml
+++ b/fern/definition/pentest/dns/takeover.yml
@@ -40,7 +40,7 @@ types:
       timeout: integer
   PentestDomainTakeoverResult:
     properties:
-      domainTakeovers: list<DomainTakeover>
+      domainTakeovers: optional<list<DomainTakeover>>
   PentestDomainTakeoverReport:
     properties:
       config: PentestDomainTakeoverConfig

--- a/fern/definition/pentest/dns/takeover.yml
+++ b/fern/definition/pentest/dns/takeover.yml
@@ -10,6 +10,15 @@ types:
       httpStatus: optional<integer>
       nxDomain: boolean
       service: string
+  # Config for a domain takeover check
+  PentestDomainTakeoverConfig:
+    properties:
+      targets: list<string>
+      targetFiles: optional<list<string>>
+      fingerprintsFile: string
+      successfulOnly: boolean
+      verifyTls: boolean
+      timeout: integer
   # Report
   HostingService:
     properties:
@@ -29,15 +38,7 @@ types:
       cname: string
       returnsNXDomain: boolean
       response: optional<DomainTakeoverResponse>
-      hostingServices: list<HostingService>
-  PentestDomainTakeoverConfig:
-    properties:
-      targets: list<string>
-      targetFiles: optional<list<string>>
-      fingerprintsFile: string
-      successfulOnly: boolean
-      verifyTls: boolean
-      timeout: integer
+      hostingServices: optional<list<HostingService>>
   PentestDomainTakeoverResult:
     properties:
       domainTakeovers: optional<list<DomainTakeover>>


### PR DESCRIPTION
### TL;DR

Made `domainTakeovers` field optional in the `PentestDomainTakeoverResult` type.


## TODO

* Update Processor
* Update Tests
* Update compiler to have successful only as TRUE and remove Parameter