### PR TITLE
Update Discover Subdomains Passive

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -139,12 +139,12 @@ func (a *OsintScan) InitDiscoverCommand() {
 			}
 
 			// Config Flags
-			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			requestsPerSecond, err := cmd.Flags().GetInt("requests-per-second")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			requestsPerSecond, err := cmd.Flags().GetInt("requests-per-second")
+			maxEnumerationTime, err := cmd.Flags().GetInt("max-enumeration-time")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -159,14 +159,9 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			maxEnumerationTime, err := cmd.Flags().GetInt("max-enumeration-time")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 
 			// Create config
-			config := getDiscoverDNSPassiveSubdomainConfig(domain, threads, timeout, dnsResolvers, requestsPerSecond, maxEnumerationTime)
+			config := getDiscoverDNSPassiveSubdomainConfig(domain, threads, timeout, requestsPerSecond, maxEnumerationTime)
 
 			// Create report
 			report, err := subdomain.GetDomainSubdomainsPassive(cmd.Context(), config)
@@ -181,9 +176,9 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("max-enumeration-time", 3, "Maximum time (in minutes) to run discovery")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("max-enumeration-time", 10, "Maximum time (in minutes) to run discovery")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainPassiveCmd.MarkFlagRequired("domain")
@@ -408,7 +403,7 @@ func getDiscoverDNSForwardReverseConfig(domain string) dnsfern.DiscoverDnsForwar
 }
 
 // getDiscoverDNSPassiveSubdomainConfig creates and returns a configuration for passive subdomain discovery
-func getDiscoverDNSPassiveSubdomainConfig(domain string, threads, timeout int, dnsResolvers []string, requestsPerSecond int, maxEnumerationTime int) dnsfern.DiscoverDnsSubdomainConfig {
+func getDiscoverDNSPassiveSubdomainConfig(domain string, threads, timeout int, requestsPerSecond int, maxEnumerationTime int) dnsfern.DiscoverDnsSubdomainConfig {
 	return dnsfern.DiscoverDnsSubdomainConfig{
 		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypePassive)),
 		Passive: &dnsfern.DiscoverDnsSubdomainPassiveConfig{

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -40,9 +40,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			config := dnsfern.DiscoverDnsCertsConfig{
-				Domain: domain,
-			}
+			config := getDiscoverDNSCertsConfig(domain)
 
 			report, err := dns.DiscoverDomainCerts(cmd.Context(), config)
 			if err != nil {
@@ -73,9 +71,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			config := dnsfern.DiscoverDnsRecordsConfig{
-				Domain: domain,
-			}
+			config := getDiscoverDNSRecordsConfig(domain)
 
 			report, err := dns.DiscoverDomainDNSRecords(cmd.Context(), config)
 			if err != nil {
@@ -106,9 +102,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			config := dnsfern.DiscoverDnsForwardReverseConfig{
-				Domain: domain,
-			}
+			config := getDiscoverDNSForwardReverseConfig(domain)
 
 			report := dns.GetForwardReverseDNSLookup(config)
 			a.OutputSignal.Content = report
@@ -144,13 +138,35 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			// Create config
-			config := dnsfern.DiscoverDnsSubdomainConfig{
-				DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypePassive)),
-				Passive: &dnsfern.DiscoverDnsSubdomainPassiveConfig{
-					Domain: domain,
-				},
+			// Config Flags
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
 			}
+			requestsPerSecond, err := cmd.Flags().GetInt("requests-per-second")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			threads, err := cmd.Flags().GetInt("threads")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			maxEnumerationTime, err := cmd.Flags().GetInt("max-enumeration-time")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Create config
+			config := getDiscoverDNSPassiveSubdomainConfig(domain, threads, timeout, dnsResolvers, requestsPerSecond, maxEnumerationTime)
 
 			// Create report
 			report, err := subdomain.GetDomainSubdomainsPassive(cmd.Context(), config)
@@ -164,6 +180,11 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Target Flags
 	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
+	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{"8.8.8.8:53"}, "DNS resolvers to use for queries")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("max-enumeration-time", 10, "Maximum time (in minutes) to run discovery")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainPassiveCmd.MarkFlagRequired("domain")
@@ -263,19 +284,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 					return
 				}
 			}
-			config := dnsfern.DiscoverDnsSubdomainConfig{
-				DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeActive)),
-				Active: &dnsfern.DiscoverDnsSubdomainActiveConfig{
-					Domain:       domain,
-					Subdomains:   allSubdomains,
-					WordlistSize: wordlistSizeEnum,
-					WordlistFile: &wordlistFile,
-					Threads:      threads,
-					MaxDepth:     maxDepth,
-					Timeout:      timeout,
-					DnsResolver:  &dnsResolver,
-				},
-			}
+			config := getDiscoverDNSActiveSubdomainConfig(domain, allSubdomains, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, &dnsResolver)
 
 			report, err := subdomain.GetDomainSubdomainsActive(cmd.Context(), config)
 			if err != nil {
@@ -293,7 +302,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainActiveCmd.Flags().StringSlice("subdomains", []string{}, "A list of subdomain names to test during discovery")
 	discoverDNSSubdomainActiveCmd.Flags().String("wordlist-size", "", "The size of the in-built wordlist to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().String("wordlist-file", "", "The file containing the wordlist to use for discovery")
-	discoverDNSSubdomainActiveCmd.Flags().Int("threads", 20, "Number of parallel threads to use for discovery")
+	discoverDNSSubdomainActiveCmd.Flags().Int("threads", 10, "Number of parallel threads to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("max-depth", 2, "Maximum recursion depth for subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 0, "Maximum time (in minutes) to spend on subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().String("dns-resolver", "", "Custom DNS resolver/server to use for queries (e.g. 1.1.1.1:53)")
@@ -376,4 +385,57 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverShodanCmd.AddCommand(discoverShodanHostnameCmd)
 
 	a.RootCmd.AddCommand(discoverCmd)
+}
+
+// getDiscoverDNSCertsConfig creates and returns a configuration for DNS certificate discovery
+func getDiscoverDNSCertsConfig(domain string) dnsfern.DiscoverDnsCertsConfig {
+	return dnsfern.DiscoverDnsCertsConfig{
+		Domain: domain,
+	}
+}
+
+// getDiscoverDNSRecordsConfig creates and returns a configuration for DNS records discovery
+func getDiscoverDNSRecordsConfig(domain string) dnsfern.DiscoverDnsRecordsConfig {
+	return dnsfern.DiscoverDnsRecordsConfig{
+		Domain: domain,
+	}
+}
+
+// getDiscoverDNSForwardReverseConfig creates and returns a configuration for forward/reverse DNS lookup
+func getDiscoverDNSForwardReverseConfig(domain string) dnsfern.DiscoverDnsForwardReverseConfig {
+	return dnsfern.DiscoverDnsForwardReverseConfig{
+		Domain: domain,
+	}
+}
+
+// getDiscoverDNSPassiveSubdomainConfig creates and returns a configuration for passive subdomain discovery
+func getDiscoverDNSPassiveSubdomainConfig(domain string, threads, timeout int, dnsResolvers []string, requestsPerSecond int, maxEnumerationTime int) dnsfern.DiscoverDnsSubdomainConfig {
+	return dnsfern.DiscoverDnsSubdomainConfig{
+		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypePassive)),
+		Passive: &dnsfern.DiscoverDnsSubdomainPassiveConfig{
+			Domain:             domain,
+			Threads:            threads,
+			Timeout:            timeout,
+			DnsResolvers:       dnsResolvers,
+			RequestsPerSecond:  requestsPerSecond,
+			MaxEnumerationTime: maxEnumerationTime,
+		},
+	}
+}
+
+// getDiscoverDNSActiveSubdomainConfig creates and returns a configuration for active subdomain discovery
+func getDiscoverDNSActiveSubdomainConfig(domain string, subdomains []string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout int, dnsResolver *string) dnsfern.DiscoverDnsSubdomainConfig {
+	return dnsfern.DiscoverDnsSubdomainConfig{
+		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeActive)),
+		Active: &dnsfern.DiscoverDnsSubdomainActiveConfig{
+			Domain:       domain,
+			Subdomains:   subdomains,
+			WordlistSize: wordlistSize,
+			WordlistFile: wordlistFile,
+			Threads:      threads,
+			MaxDepth:     maxDepth,
+			Timeout:      timeout,
+			DnsResolver:  dnsResolver,
+		},
+	}
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -180,7 +180,6 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Target Flags
 	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
-	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{"8.8.8.8:53"}, "DNS resolvers to use for queries")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("timeout", 30, "Timeout per request in seconds")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning")
@@ -416,7 +415,6 @@ func getDiscoverDNSPassiveSubdomainConfig(domain string, threads, timeout int, d
 			Domain:             domain,
 			Threads:            threads,
 			Timeout:            timeout,
-			DnsResolvers:       dnsResolvers,
 			RequestsPerSecond:  requestsPerSecond,
 			MaxEnumerationTime: maxEnumerationTime,
 		},

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -67,12 +67,7 @@ func (a *OsintScan) InitEnumerateCommand() {
 				}
 			}
 
-			config := dnsfern.EnumerateDnsZoneTransferConfig{
-				Domains:     domains,
-				Nameserver:  &nameserver,
-				DnsResolver: &dnsResolver,
-				Timeout:     timeout,
-			}
+			config := getEnumerateDnsZoneTransferConfig(domains, nameserver, dnsResolver, timeout)
 
 			report, err := zonetransfer.TestZoneTransfer(cmd.Context(), config)
 			if err != nil {
@@ -94,4 +89,14 @@ func (a *OsintScan) InitEnumerateCommand() {
 	enumerateDNSCmd.AddCommand(enumerateDNSZoneTransferCmd)
 
 	a.RootCmd.AddCommand(enumerateCmd)
+}
+
+// getEnumerateDnsZoneTransferConfig creates and returns a configuration for DNS zone transfer enumeration
+func getEnumerateDnsZoneTransferConfig(domains []string, nameserver, dnsResolver string, timeout int) dnsfern.EnumerateDnsZoneTransferConfig {
+	return dnsfern.EnumerateDnsZoneTransferConfig{
+		Domains:     domains,
+		Nameserver:  &nameserver,
+		DnsResolver: &dnsResolver,
+		Timeout:     timeout,
+	}
 }

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -67,7 +67,7 @@ func (a *OsintScan) InitEnumerateCommand() {
 				}
 			}
 
-			config := getEnumerateDnsZoneTransferConfig(domains, nameserver, dnsResolver, timeout)
+			config := getEnumerateDNSZoneTransferConfig(domains, nameserver, dnsResolver, timeout)
 
 			report, err := zonetransfer.TestZoneTransfer(cmd.Context(), config)
 			if err != nil {
@@ -91,8 +91,8 @@ func (a *OsintScan) InitEnumerateCommand() {
 	a.RootCmd.AddCommand(enumerateCmd)
 }
 
-// getEnumerateDnsZoneTransferConfig creates and returns a configuration for DNS zone transfer enumeration
-func getEnumerateDnsZoneTransferConfig(domains []string, nameserver, dnsResolver string, timeout int) dnsfern.EnumerateDnsZoneTransferConfig {
+// getEnumerateDNSZoneTransferConfig creates and returns a configuration for DNS zone transfer enumeration
+func getEnumerateDNSZoneTransferConfig(domains []string, nameserver, dnsResolver string, timeout int) dnsfern.EnumerateDnsZoneTransferConfig {
 	return dnsfern.EnumerateDnsZoneTransferConfig{
 		Domains:     domains,
 		Nameserver:  &nameserver,

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -1,4 +1,5 @@
 types:
+# Enums
   DiscoverDnsSubdomainType:
     enum:
       - ACTIVE
@@ -9,6 +10,11 @@ types:
       - SMALL
       - MEDIUM
       - LARGE
+  PassiveSource:
+    enum:
+      - CRTSH
+      - WAYBACKARCHIVE
+# Configs
   DiscoverDnsSubdomainActiveConfig:
     properties:
       domain: string
@@ -22,6 +28,12 @@ types:
   DiscoverDnsSubdomainPassiveConfig:
     properties:
       domain: string
+      threads: integer
+      timeout: integer
+      dnsResolvers: list<string>
+      requestsPerSecond: integer
+      maxEnumerationTime: integer
+# Reports
   DiscoverDnsSubdomainConfig:
     discriminant: discoveryType
     union:

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -10,10 +10,6 @@ types:
       - SMALL
       - MEDIUM
       - LARGE
-  PassiveSource:
-    enum:
-      - CRTSH
-      - WAYBACKARCHIVE
 # Configs
   DiscoverDnsSubdomainActiveConfig:
     properties:
@@ -30,7 +26,6 @@ types:
       domain: string
       threads: integer
       timeout: integer
-      dnsResolvers: list<string>
       requestsPerSecond: integer
       maxEnumerationTime: integer
 # Reports

--- a/internal/discover/dns/subdomain/passive.go
+++ b/internal/discover/dns/subdomain/passive.go
@@ -43,7 +43,6 @@ func getSubdomainsPassive(ctx context.Context, config dnsfern.DiscoverDnsSubdoma
 		Threads:            config.Threads,
 		Timeout:            config.Timeout,
 		MaxEnumerationTime: config.MaxEnumerationTime,
-		Resolvers:          config.DnsResolvers,
 		RateLimit:          config.RequestsPerSecond,
 	}
 

--- a/internal/discover/dns/subdomain/passive.go
+++ b/internal/discover/dns/subdomain/passive.go
@@ -16,7 +16,7 @@ func GetDomainSubdomainsPassive(ctx context.Context, config dnsfern.DiscoverDnsS
 	errors := []string{}
 
 	// Get all valid subdomains using passive enumeration
-	subdomains, err := getSubdomainsPassive(ctx, config.GetPassive().Domain)
+	subdomains, err := getSubdomainsPassive(ctx, *config.Passive)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
@@ -37,11 +37,14 @@ func GetDomainSubdomainsPassive(ctx context.Context, config dnsfern.DiscoverDnsS
 // SubdomainsEnumReport represents the report of all subdomains for a given domain including all non-fatal errors that occurred.
 
 // getSubdomainsPassive runs subfinder in passive mode for a single domain and returns the discovered subdomains.
-func getSubdomainsPassive(ctx context.Context, domain string) ([]string, error) {
+func getSubdomainsPassive(ctx context.Context, config dnsfern.DiscoverDnsSubdomainPassiveConfig) ([]string, error) {
+	// Set subfinder config
 	subfinderOpts := &runner.Options{
-		Threads:            10, // Number of threads for enumeration
-		Timeout:            30, // Timeout in seconds for sources
-		MaxEnumerationTime: 10, // Max time in minutes for enumeration
+		Threads:            config.Threads,
+		Timeout:            config.Timeout,
+		MaxEnumerationTime: config.MaxEnumerationTime,
+		Resolvers:          config.DnsResolvers,
+		RateLimit:          config.RequestsPerSecond,
 	}
 
 	// Initialize subfinder runner
@@ -52,7 +55,7 @@ func getSubdomainsPassive(ctx context.Context, domain string) ([]string, error) 
 
 	output := &bytes.Buffer{}
 	// Run subdomain enumeration for the given domain
-	if err = subfinder.EnumerateSingleDomainWithCtx(ctx, domain, []io.Writer{output}); err != nil {
+	if err = subfinder.EnumerateSingleDomainWithCtx(ctx, config.Domain, []io.Writer{output}); err != nil {
 		return []string{}, err
 	}
 

--- a/internal/pentest/dns/takeover/takeover.go
+++ b/internal/pentest/dns/takeover/takeover.go
@@ -37,8 +37,8 @@ func DetectDomainTakeover(ctx context.Context, config dnsfern.PentestDomainTakeo
 				continue
 			}
 
-			// Assess target for takeover
-			response, serviceResults, successful := assessTarget(url, httpClient, fingerprints, cname, returnsNXDomain, config.SuccessfulOnly)
+			// Send request to target
+			response, serviceResults, successful := sendRequest(url, httpClient, fingerprints, cname, returnsNXDomain, config.SuccessfulOnly)
 			if !config.SuccessfulOnly || successful {
 				takeoverResult := dnsfern.DomainTakeover{
 					Target:          url,
@@ -63,9 +63,9 @@ func DetectDomainTakeover(ctx context.Context, config dnsfern.PentestDomainTakeo
 	return &report, nil
 }
 
-// assessTarget sends a request to the target and analyzes the response for domain takeovers.
+// sendRequest sends a request to the target and analyzes the response for domain takeovers.
 // Returns the response, detected services, and whether a successful takeover was found.
-func assessTarget(url string, client *http.Client, fingerprints []*dnsfern.DomainTakeoverFingerprint, cname string, returnsNXDomain bool, onlySuccessful bool) (*dnsfern.DomainTakeoverResponse, []*dnsfern.HostingService, bool) {
+func sendRequest(url string, client *http.Client, fingerprints []*dnsfern.DomainTakeoverFingerprint, cname string, returnsNXDomain bool, onlySuccessful bool) (*dnsfern.DomainTakeoverResponse, []*dnsfern.HostingService, bool) {
 	response := dnsfern.DomainTakeoverResponse{}
 
 	if !returnsNXDomain {


### PR DESCRIPTION
## Enhanced DNS Subdomain Discovery Configuration

This PR adds advanced configuration options for passive subdomain discovery to address rate limiting issues:

- Added new CLI flags for passive subdomain discovery:
  - `--requests-per-second` - Rate limiting control
  - `--timeout` - Request timeout in seconds (default: 30)
  - `--threads` - Concurrent threads (default: 10, reduced from 20)
  - `--max-enumeration-time` - Maximum discovery runtime in minutes (default: 10)

- Refactored configuration handling by extracting config creation into dedicated helper functions:
  - `getDiscoverDnsCertsConfig`
  - `getDiscoverDnsRecordsConfig`
  - `getDiscoverDnsForwardReverseConfig`
  - `getDiscoverDnsSubdomainPassiveConfig`
  - `getDiscoverDnsSubdomainActiveConfig`
  - `getEnumerateDnsZoneTransferConfig`

- Renamed `assessTarget` to the more descriptive `sendRequest` in the takeover detection code

- Updated the Fern definition to include new passive subdomain configuration parameters