### PR TITLE
Add regex support for AWS Elastic Beanstalk takeover detection

### DIFF
--- a/configs/pentest/dns/takeover/fingerprints.json
+++ b/configs/pentest/dns/takeover/fingerprints.json
@@ -1,7 +1,7 @@
 [
     {
       "cicd_pass": true,
-      "cname": ["elasticbeanstalk.com"],
+      "cname": ["^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]\\.(us-east-1|us-east-2|us-west-1|us-west-2|eu-west-1|eu-west-2|eu-west-3|eu-central-1|eu-north-1|ap-south-1|ap-southeast-1|ap-southeast-2|ap-northeast-1|ap-northeast-2|ap-northeast-3|ca-central-1|sa-east-1)\\.elasticbeanstalk\\.com\\.$"],
       "discussion": "[Issue #194](https://github.com/EdOverflow/can-i-take-over-xyz/issues/194)",
       "documentation": "",
       "fingerprint": "NXDOMAIN",

--- a/internal/pentest/dns/takeover/helpers.go
+++ b/internal/pentest/dns/takeover/helpers.go
@@ -60,8 +60,17 @@ func isVulnerable(cname string, body *string, returnsNXDomain bool, fp dnsfern.D
 		cnameMatch := false
 		if len(fp.Cname) > 0 {
 			for _, fingerprintCname := range fp.Cname {
-				if strings.Contains(cname, fingerprintCname) {
-					cnameMatch = true
+				// Check if pattern looks like regex (contains regex metacharacters)
+				if strings.ContainsAny(fingerprintCname, "^$.*+?{}[]\\|()") {
+					matched, err := regexp.MatchString(fingerprintCname, cname)
+					if err == nil && matched {
+						cnameMatch = true
+					}
+				} else {
+					// Use simple string contains for backward compatibility
+					if strings.Contains(cname, fingerprintCname) {
+						cnameMatch = true
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### TL;DR

Added regex support for CNAME matching in DNS takeover detection, with specific improvements for AWS Elastic Beanstalk environments.

### What changed?

- Enhanced the CNAME matching logic in `isVulnerable()` to support regex patterns
- Updated the Elastic Beanstalk fingerprint to use a regex pattern that properly matches region-specific subdomains
- Maintained backward compatibility for simple string matching

### How to test?

1. Test DNS takeover detection against various Elastic Beanstalk environments with region-specific CNAMEs
2. Verify that the regex pattern correctly identifies vulnerable Elastic Beanstalk domains
3. Confirm that existing non-regex CNAME patterns continue to work as expected

### Why make this change?

The previous implementation used simple string matching for CNAMEs, which was insufficient for services like AWS Elastic Beanstalk that use region-specific patterns. By implementing regex support, we can more accurately detect vulnerable domains while reducing false positives, particularly for AWS services that follow specific naming conventions.