### PR TITLE
Resolver Round Robin

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -113,7 +113,13 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			config := getDiscoverDNSForwardReverseConfig(domain)
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			config := getDiscoverDNSForwardReverseConfig(domain, dnsResolvers)
 
 			report := dns.GetForwardReverseDNSLookup(config)
 			a.OutputSignal.Content = report
@@ -122,6 +128,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Target Flags
 	discoverDNSForwardReverseCmd.Flags().String("domain", "", "The domain name to perform forward and reverse lookups on")
+	discoverDNSForwardReverseCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
 
 	// Mark Required Flags
 	_ = discoverDNSForwardReverseCmd.MarkFlagRequired("domain")
@@ -269,19 +276,19 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			dnsResolver, err := cmd.Flags().GetString("dns-resolver")
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			if dnsResolver != "" {
+			for _, dnsResolver := range dnsResolvers {
 				err = utils.ValidateDNSServerAddress(dnsResolver)
 				if err != nil {
-					a.OutputSignal.AddError(err)
+					a.OutputSignal.AddError(fmt.Errorf("invalid DNS resolver: %w", err))
 					return
 				}
 			}
-			config := getDiscoverDNSActiveSubdomainConfig(domain, allSubdomains, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, &dnsResolver)
+			config := getDiscoverDNSActiveSubdomainConfig(domain, allSubdomains, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, dnsResolvers)
 
 			report, err := subdomain.GetDomainSubdomainsActive(cmd.Context(), config)
 			if err != nil {
@@ -302,7 +309,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainActiveCmd.Flags().Int("threads", 10, "Number of parallel threads to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("max-depth", 2, "Maximum recursion depth for subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 0, "Maximum time (in minutes) to spend on subdomain discovery")
-	discoverDNSSubdomainActiveCmd.Flags().String("dns-resolver", "", "Custom DNS resolver/server to use for queries (e.g. 1.1.1.1:53)")
+	discoverDNSSubdomainActiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainActiveCmd.MarkFlagRequired("domain")
@@ -500,9 +507,10 @@ func getDiscoverDNSRecordsConfig(domain string) dnsfern.DiscoverDnsRecordsConfig
 }
 
 // getDiscoverDNSForwardReverseConfig creates and returns a configuration for forward/reverse DNS lookup
-func getDiscoverDNSForwardReverseConfig(domain string) dnsfern.DiscoverDnsForwardReverseConfig {
+func getDiscoverDNSForwardReverseConfig(domain string, dnsResolvers []string) dnsfern.DiscoverDnsForwardReverseConfig {
 	return dnsfern.DiscoverDnsForwardReverseConfig{
-		Domain: domain,
+		Domain:       domain,
+		DnsResolvers: dnsResolvers,
 	}
 }
 
@@ -519,7 +527,7 @@ func getDiscoverDNSPassiveSubdomainConfig(domain string, requestsPerSecond int, 
 }
 
 // getDiscoverDNSActiveSubdomainConfig creates and returns a configuration for active subdomain discovery
-func getDiscoverDNSActiveSubdomainConfig(domain string, subdomains []string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout int, dnsResolver *string) dnsfern.DiscoverDnsSubdomainConfig {
+func getDiscoverDNSActiveSubdomainConfig(domain string, subdomains []string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout int, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
 	return dnsfern.DiscoverDnsSubdomainConfig{
 		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeActive)),
 		Active: &dnsfern.DiscoverDnsSubdomainActiveConfig{
@@ -530,7 +538,7 @@ func getDiscoverDNSActiveSubdomainConfig(domain string, subdomains []string, wor
 			Threads:      threads,
 			MaxDepth:     maxDepth,
 			Timeout:      timeout,
-			DnsResolver:  dnsResolver,
+			DnsResolvers: dnsResolvers,
 		},
 	}
 }

--- a/fern/definition/discover/dns/forwardreverse.yml
+++ b/fern/definition/discover/dns/forwardreverse.yml
@@ -1,11 +1,15 @@
 types:
+# Lookup Struct
   LookupDetails:
     properties:
       forwardIp: optional<string>
       reversePtrs: optional<list<string>>
+# Config Struct
   DiscoverDnsForwardReverseConfig:
     properties:
       domain: string
+      dnsResolvers: optional<list<string>>
+# Report Structs
   DiscoverDnsForwardReverseResult:
     properties:
       lookups: optional<list<LookupDetails>>

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -21,7 +21,7 @@ types:
       threads: integer
       maxDepth: integer
       timeout: integer
-      dnsResolver: optional<string>
+      dnsResolvers: optional<list<string>>
   DiscoverDnsSubdomainPassiveConfig:
     properties:
       domain: string

--- a/internal/discover/dns/forwardreverse.go
+++ b/internal/discover/dns/forwardreverse.go
@@ -1,9 +1,13 @@
 package dns
 
 import (
+	"context"
+	"math/rand"
 	"net"
 
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
+	"github.com/Method-Security/osintscan/utils"
+	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // GetForwardReverseDNSLookup performs both forward (A/AAAA) and reverse (PTR) DNS lookups for a given FQDN.
@@ -11,9 +15,9 @@ import (
 func GetForwardReverseDNSLookup(config dnsfern.DiscoverDnsForwardReverseConfig) dnsfern.DiscoverDnsForwardReverseReport {
 	errors := []string{}
 
-	lookUps, err := getLookups(config.Domain, errors)
-	if err != nil {
-		errors = append(errors, err.Error())
+	lookUps, errs := getLookups(config.Domain, config.DnsResolvers)
+	if len(errs) > 0 {
+		errors = append(errors, errs...)
 	}
 
 	results := dnsfern.DiscoverDnsForwardReverseResult{
@@ -28,28 +32,40 @@ func GetForwardReverseDNSLookup(config dnsfern.DiscoverDnsForwardReverseConfig) 
 	return report
 }
 
-func getLookups(domain string, errors []string) ([]*dnsfern.LookupDetails, error) {
+func getLookups(domain string, dnsResolvers []string) ([]*dnsfern.LookupDetails, []string) {
+	ctx := context.Background()
+	log := svc1log.FromContext(ctx)
+	errors := []string{}
+
+	// Pick a random resolver from the list
+	resolver := utils.GetResolver(dnsResolvers[rand.Intn(len(dnsResolvers))], log)
+
 	// Resolve the IP addresses for the given FQDN (forward lookup)
-	ips, err := net.LookupIP(domain)
+	ips, err := resolver.LookupHost(ctx, domain)
 	if err != nil {
 		errors = append(errors, err.Error())
+		return []*dnsfern.LookupDetails{}, errors
 	}
 
 	lookUps := []*dnsfern.LookupDetails{}
-	for _, ip := range ips {
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			continue
+		}
+
 		// Perform a reverse lookup (PTR record) for each IP
-		names, err := net.LookupAddr(ip.String())
+		names, err := resolver.LookupAddr(ctx, ip.String())
 		if err != nil {
 			errors = append(errors, err.Error())
 		}
 
 		// Store resolved hostnames per IP
-		ipStr := ip.String()
 		lookUps = append(lookUps, &dnsfern.LookupDetails{
 			ForwardIp:   &ipStr,
 			ReversePtrs: names,
 		})
 	}
 
-	return lookUps, nil
+	return lookUps, errors
 }

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -162,7 +162,9 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 
 			// Round robin resolver selection
 			currentIndex := atomic.AddInt64(&resolverIndex, 1) - 1
-			resolver := resolvers[currentIndex%int64(len(resolvers))]
+			resolverIdx := currentIndex % int64(len(resolvers))
+			resolver := resolvers[resolverIdx]
+			log.Info("Using resolver", svc1log.SafeParam("resolver_index", resolverIdx))
 
 			// Capture the duration of the lookup
 			start := time.Now()

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -25,7 +25,7 @@ func GetDomainSubdomainsActive(ctx context.Context, config dnsfern.DiscoverDnsSu
 	errors := []string{}
 
 	// Run the active subdomain discovery
-	subdomains, err := getSubdomainsActive(ctx, activeConfig.Domain, activeConfig.Subdomains, activeConfig.Threads, activeConfig.MaxDepth, activeConfig.Timeout, *activeConfig.DnsResolver)
+	subdomains, err := getSubdomainsActive(ctx, activeConfig.Domain, activeConfig.Subdomains, activeConfig.Threads, activeConfig.MaxDepth, activeConfig.Timeout, activeConfig.DnsResolvers)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
@@ -66,7 +66,7 @@ func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolve
 }
 
 // getSubdomainsActive performs recursive bruteforce subdomain enumeration with concurrency and wildcard detection.
-func getSubdomainsActive(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, dnsServerAddress string) ([]string, error) {
+func getSubdomainsActive(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, dnsServerAddresses []string) ([]string, error) {
 	log := svc1log.FromContext(ctx)
 	subdomains := []string{}
 	subdomainsSet := make(map[string]struct{}) // To track unique valid subdomains
@@ -79,12 +79,14 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Minute)
 		defer cancel()
 	}
-
-	resolver := utils.GetResolver(dnsServerAddress, log)
+	resolvers := []*net.Resolver{}
+	for _, dnsServerAddress := range dnsServerAddresses {
+		resolvers = append(resolvers, utils.GetResolver(dnsServerAddress, log))
+	}
 
 	// First iteration - test all base subdomains for wildcards
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
-	wildcardDNS, err := detectWildcardDNS(ctx, domain, resolver)
+	wildcardDNS, err := detectWildcardDNS(ctx, domain, resolvers[0])
 	if err != nil {
 		return []string{}, err
 	}
@@ -96,7 +98,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 	log.Info("Generating base permutations", svc1log.SafeParam("domain", domain))
 	basePermutations := generatePermutations([]string{domain}, subdomainList)
-	validBaseSubdomains := testPermutations(ctx, basePermutations, resolver, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth)
+	validBaseSubdomains := testPermutations(ctx, basePermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth)
 
 	// For each subsequent depth, only build on valid subdomains from previous iteration
 	log.Info("Starting subdomain discovery", svc1log.SafeParam("base_subdomain count", len(validBaseSubdomains)))
@@ -115,7 +117,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 		validSubdomains := []string{}
 		for _, subdomain := range currentDepthSubdomains {
-			wildcardDNS, err := detectWildcardDNS(ctx, subdomain, resolver)
+			wildcardDNS, err := detectWildcardDNS(ctx, subdomain, resolvers[0]) // Use resolvers[0] for wildcard detection
 			if err != nil {
 				continue
 			}
@@ -128,7 +130,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		}
 
 		newPermutations := generatePermutations(validSubdomains, subdomainList)
-		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolver, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth)
+		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth)
 	}
 
 	return subdomains, nil
@@ -136,13 +138,14 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 // testPermutations concurrently tests a list of subdomain permutations for DNS resolution.
 // Uses a semaphore to limit concurrency and mutexes to protect shared state.
-func testPermutations(ctx context.Context, permutations []string, resolver *net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int) []string {
+func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int) []string {
 	log := svc1log.FromContext(ctx)
 	var validSubdomains []string
 	validSubdomainsMutex := &sync.Mutex{}
 
 	totalPermutations := len(permutations)
 	var completedCount int64
+	var resolverIndex int64 // For round robin resolver selection
 
 	for _, testSubdomain := range permutations {
 		wg.Add(1)
@@ -156,6 +159,10 @@ func testPermutations(ctx context.Context, permutations []string, resolver *net.
 			case <-ctx.Done():
 				return
 			}
+
+			// Round robin resolver selection
+			currentIndex := atomic.AddInt64(&resolverIndex, 1) - 1
+			resolver := resolvers[currentIndex%int64(len(resolvers))]
 
 			// Capture the duration of the lookup
 			start := time.Now()


### PR DESCRIPTION
### TL;DR

Added support for multiple DNS resolvers in the DNS discovery commands.

### What changed?

- Changed the `dns-resolver` flag to `dns-resolvers` in the DNS subdomain active discovery command, allowing users to specify multiple DNS resolvers
- Added the `dns-resolvers` flag to the DNS forward/reverse lookup command
- Updated the internal implementation to support multiple resolvers with round-robin selection
- Modified the configuration structs in the Fern definition files to support lists of DNS resolvers
- Enhanced error handling for DNS resolver validation