### PR TITLE
Fix CDN

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -103,7 +103,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSCmd.AddCommand(discoverDNSRecordsCmd)
 
 	discoverDNSForwardReverseCmd := &cobra.Command{
-		Use:   "forwardreverse",
+		Use:   "forward-reverse",
 		Short: "Perform forward and reverse DNS lookups",
 		Long:  `Perform both forward and reverse DNS lookups for the specified domain to identify associated IPs and hostnames.`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -459,7 +459,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 		Long:  `Check if an IP address belongs to a known CDN provider by comparing against known CDN IP ranges.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse flags
-			ipAddresses, err := cmd.Flags().GetStringSlice("ip-addresses")
+			domains, err := cmd.Flags().GetStringSlice("domains")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -469,9 +469,25 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if len(dnsResolvers) == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("no DNS resolvers provided"))
+				return
+			}
+			for _, dnsResolver := range dnsResolvers {
+				err = utils.ValidateDNSServerAddress(dnsResolver)
+				if err != nil {
+					a.OutputSignal.AddError(fmt.Errorf("invalid DNS resolver: %w", err))
+					return
+				}
+			}
 
 			// Create config
-			config := getDiscoverCdnConfig(ipAddresses, fingerprintsFile)
+			config := getDiscoverCdnConfig(domains, dnsResolvers, fingerprintsFile)
 
 			// Create report
 			report := cdn.RunDiscoverCdns(cmd.Context(), config)
@@ -480,11 +496,12 @@ func (a *OsintScan) InitDiscoverCommand() {
 	}
 
 	// Target Flags
-	discoverCdnCmd.Flags().StringSlice("ip-addresses", []string{}, "The IP address to check against CDN provider ranges")
+	discoverCdnCmd.Flags().StringSlice("domains", []string{}, "The domain names to check against CDN provider ranges")
+	discoverCdnCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
 	discoverCdnCmd.Flags().String("fingerprints-file", "/opt/method/osintscan/var/conf/discover/cdn/providers.json", "The path to the CDN fingerprints file")
 
 	// Mark Required Flags
-	_ = discoverCdnCmd.MarkFlagRequired("ip-addresses")
+	_ = discoverCdnCmd.MarkFlagRequired("domains")
 
 	// Add command to the 'discover' command
 	discoverCmd.AddCommand(discoverCdnCmd)
@@ -558,9 +575,11 @@ func getDiscoverDNSIntelligentSubdomainConfig(domains []string, threads int, tim
 }
 
 // getDiscoverCdnConfig creates and returns a configuration for CDN discovery
-func getDiscoverCdnConfig(ipAddresses []string, fingerprintsFile string) cdnfern.DiscoverCdnConfig {
+func getDiscoverCdnConfig(domains []string, dnsResolvers []string, fingerprintsFile string) cdnfern.DiscoverCdnConfig {
 	return cdnfern.DiscoverCdnConfig{
-		IpAddresses:      ipAddresses,
+		Domains:          domains,
+		DnsResolvers:     dnsResolvers,
 		FingerprintsFile: fingerprintsFile,
 	}
+
 }

--- a/fern/definition/discover/cdn.yml
+++ b/fern/definition/discover/cdn.yml
@@ -18,7 +18,8 @@ types:
 # Report Config
   DiscoverCdnConfig:
     properties:
-      ipAddresses: list<string>
+      domains: list<string>
+      dnsResolvers: optional<list<string>>
       fingerprintsFile: string
 # Report Structs
   CdnMatch:
@@ -27,6 +28,7 @@ types:
       matchedRange: string
   IpCdnResult:
     properties:
+      domain: string
       ipAddress: string
       match: optional<CdnMatch>
   DiscoverCdnResult:

--- a/internal/discover/cdn.go
+++ b/internal/discover/cdn.go
@@ -9,14 +9,17 @@ import (
 	"net/netip"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	// Generated
 	cdnfern "github.com/Method-Security/osintscan/generated/go/discover"
+	// Utils
+	"github.com/Method-Security/osintscan/utils"
 	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// RunDiscoverCdns checks IP addresses against known CDN provider ranges
+// RunDiscoverCdns resolves domains to IP addresses and checks them against known CDN provider ranges
 // and returns a report with any matches found
 func RunDiscoverCdns(ctx context.Context, config cdnfern.DiscoverCdnConfig) *cdnfern.DiscoverCdnReport {
 	log := svc1log.FromContext(ctx)
@@ -39,32 +42,52 @@ func RunDiscoverCdns(ctx context.Context, config cdnfern.DiscoverCdnConfig) *cdn
 		return report
 	}
 
-	// Iterate through each IP address provided in the config
-	for _, ipAddress := range config.IpAddresses {
-		log.Info("Checking IP address", svc1log.SafeParam("ipAddress", ipAddress))
+	// Create resolvers for each provided DNS server
+	resolvers := []*net.Resolver{}
+	for _, dnsServerAddress := range config.DnsResolvers {
+		resolvers = append(resolvers, utils.GetResolver(dnsServerAddress, log))
+	}
 
-		// Initialize result structure for this specific IP
-		ipResult := &cdnfern.IpCdnResult{
-			IpAddress: ipAddress,
-			Match:     nil,
-		}
+	// Iterate through each domain provided in the config
+	for _, domain := range config.Domains {
+		log.Info("Resolving domain", svc1log.SafeParam("domain", domain))
 
-		// Parse and validate the IP address string
-		ip := net.ParseIP(strings.TrimSpace(ipAddress))
-		if ip == nil {
-			log.Error("Invalid IP address", svc1log.SafeParam("ipAddress", ipAddress))
-			continue
-		}
+		// Resolve domain to IP addresses using round-robin resolvers
+		ipAddresses, resolveErrors := resolvedomainToIPs(ctx, domain, resolvers, log)
 
-		// Check if this IP falls within any CDN provider ranges
-		match, errors := checkIPAgainstCdnRanges(ctx, ip, cdnFingerprints)
-		if match != nil {
-			ipResult.Match = match
+		// Add any resolution errors to the report
+		report.Errors = append(report.Errors, resolveErrors...)
+
+		// Check each resolved IP address against CDN ranges
+		for _, ipAddress := range ipAddresses {
+			log.Info("Checking resolved IP address", svc1log.SafeParam("domain", domain), svc1log.SafeParam("ipAddress", ipAddress))
+
+			// Initialize result structure for this specific IP
+			ipResult := &cdnfern.IpCdnResult{
+				Domain:    domain,
+				IpAddress: ipAddress,
+				Match:     nil,
+			}
+
+			// Parse and validate the IP address string
+			ip := net.ParseIP(strings.TrimSpace(ipAddress))
+			if ip == nil {
+				log.Error("Invalid IP address from resolution", svc1log.SafeParam("domain", domain), svc1log.SafeParam("ipAddress", ipAddress))
+				continue
+			}
+
+			// Check if this IP falls within any CDN provider ranges
+			match, errors := checkIPAgainstCdnRanges(ctx, ip, cdnFingerprints)
+			if match != nil {
+				ipResult.Match = match
+			}
+
+			// Always add the result, whether match found or not
 			result.Results = append(result.Results, ipResult)
-		}
 
-		// Accumulate any errors encountered during checking
-		report.Errors = append(report.Errors, errors...)
+			// Accumulate any errors encountered during checking
+			report.Errors = append(report.Errors, errors...)
+		}
 	}
 
 	// Set final result and return complete report
@@ -120,7 +143,6 @@ func checkIPAgainstCdnRanges(ctx context.Context, ip net.IP, cdnFingerprints *cd
 
 		// Check each IP range for this provider
 		for _, raw := range ranges {
-			log.Info("Checking range", svc1log.SafeParam("providerKey", providerKey), svc1log.SafeParam("raw", raw))
 			s := strings.TrimSpace(raw)
 
 			// Parse the IP range/subnet notation
@@ -151,4 +173,33 @@ func checkIPAgainstCdnRanges(ctx context.Context, ip net.IP, cdnFingerprints *cd
 	}
 
 	return nil, errors
+}
+
+// resolvedomainToIPs resolves an domain to IP addresses using round-robin resolvers
+// Returns a slice of IP address strings and any errors encountered
+func resolvedomainToIPs(ctx context.Context, domain string, resolvers []*net.Resolver, log svc1log.Logger) ([]string, []string) {
+	var resolverIndex int64
+	var ipAddresses []string
+	var errors []string
+
+	// Use round-robin resolver selection
+	currentIndex := atomic.AddInt64(&resolverIndex, 1) - 1
+	resolverIdx := currentIndex % int64(len(resolvers))
+	resolver := resolvers[resolverIdx]
+
+	log.Info("Using resolver for domain resolution", svc1log.SafeParam("resolver_index", resolverIdx), svc1log.SafeParam("domain", domain))
+
+	// Resolve the domain to IP addresses
+	ips, err := resolver.LookupHost(ctx, domain)
+	if err != nil {
+		errors = append(errors, fmt.Sprintf("failed to resolve domain %s: %v", domain, err))
+		return ipAddresses, errors
+	}
+
+	// Add all resolved IPs to the result
+	ipAddresses = append(ipAddresses, ips...)
+
+	log.Info("Resolved domain", svc1log.SafeParam("domain", domain), svc1log.SafeParam("ip_count", len(ips)))
+
+	return ipAddresses, errors
 }


### PR DESCRIPTION
### TL;DR

Enhanced the CDN discovery feature to work with domains instead of IP addresses directly.

### What changed?

- Modified the `discover cdn` command to accept domains instead of IP addresses
- Added DNS resolution functionality to automatically resolve domains to IP addresses
- Implemented support for custom DNS resolvers with validation
- Updated the command syntax from `forwardreverse` to `forward-reverse` for better readability
- Enhanced the CDN detection report to include the original domain alongside the IP address

### How to test?

1. Run the updated command with domains:
   ```
   osintscan discover cdn --domains example.com,example.org --dns-resolvers 1.1.1.1:53,8.8.8.8:53
   ```

2. Verify that the command resolves the domains to IP addresses and checks them against CDN ranges
3. Confirm that the output report includes both the original domain and the resolved IP addresses

### Why make this change?

This change improves user experience by allowing direct input of domains rather than requiring users to manually resolve IP addresses first. It also provides more context in the results by maintaining the relationship between domains and their IP addresses, making it easier to identify which domains are served by CDNs.