### PR TITLE
Implement Round Robin Resolver for Zone Transfer

### DIFF
--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -54,20 +54,24 @@ func (a *OsintScan) InitEnumerateCommand() {
 				return
 			}
 
-			dnsResolver, err := cmd.Flags().GetString("dns-resolver")
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			if dnsResolver != "" {
+			if len(dnsResolvers) == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("no DNS resolvers provided"))
+				return
+			}
+			for _, dnsResolver := range dnsResolvers {
 				err = utils.ValidateDNSServerAddress(dnsResolver)
 				if err != nil {
-					a.OutputSignal.AddError(err)
+					a.OutputSignal.AddError(fmt.Errorf("invalid DNS resolver: %w", err))
 					return
 				}
 			}
 
-			config := getEnumerateDNSZoneTransferConfig(domains, nameserver, dnsResolver, timeout)
+			config := getEnumerateDNSZoneTransferConfig(domains, nameserver, dnsResolvers, timeout)
 
 			report, err := zonetransfer.TestZoneTransfer(cmd.Context(), config)
 			if err != nil {
@@ -84,7 +88,7 @@ func (a *OsintScan) InitEnumerateCommand() {
 
 	// Config Flags
 	enumerateDNSZoneTransferCmd.Flags().Int("timeout", 30, "Timeout in seconds for each zone transfer request")
-	enumerateDNSZoneTransferCmd.Flags().String("dns-resolver", "", "Custom DNS resolver for NS lookups (e.g. 1.1.1.1:53). Only used when --nameserver is not specified")
+	enumerateDNSZoneTransferCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
 
 	enumerateDNSCmd.AddCommand(enumerateDNSZoneTransferCmd)
 
@@ -92,11 +96,11 @@ func (a *OsintScan) InitEnumerateCommand() {
 }
 
 // getEnumerateDNSZoneTransferConfig creates and returns a configuration for DNS zone transfer enumeration
-func getEnumerateDNSZoneTransferConfig(domains []string, nameserver, dnsResolver string, timeout int) dnsfern.EnumerateDnsZoneTransferConfig {
+func getEnumerateDNSZoneTransferConfig(domains []string, nameserver string, dnsResolvers []string, timeout int) dnsfern.EnumerateDnsZoneTransferConfig {
 	return dnsfern.EnumerateDnsZoneTransferConfig{
-		Domains:     domains,
-		Nameserver:  &nameserver,
-		DnsResolver: &dnsResolver,
-		Timeout:     timeout,
+		Domains:      domains,
+		Nameserver:   &nameserver,
+		DnsResolvers: dnsResolvers,
+		Timeout:      timeout,
 	}
 }

--- a/fern/definition/enumerate/dns/zonetransfer.yml
+++ b/fern/definition/enumerate/dns/zonetransfer.yml
@@ -1,17 +1,19 @@
 imports:
   dns: ../../common/dns.yml
 types:
+# Config Struct
+  EnumerateDnsZoneTransferConfig:
+    properties:
+      domains: list<string>
+      nameserver: optional<string>
+      dnsResolvers: optional<list<string>>
+      timeout: integer
+# Report Structs
   DnsZoneTransferDetails:
     properties:
       domain: string
       dnsRecords: optional<list<dns.DnsRecord>>
       success: optional<boolean>
-  EnumerateDnsZoneTransferConfig:
-    properties:
-      domains: list<string>
-      nameserver: optional<string>
-      dnsResolver: optional<string>
-      timeout: integer
   EnumerateDnsZoneTransferResult:
     properties:
       zoneTransfer: list<DnsZoneTransferDetails>

--- a/internal/enumerate/dns/zonetransfer/zonetransfer.go
+++ b/internal/enumerate/dns/zonetransfer/zonetransfer.go
@@ -18,37 +18,39 @@ import (
 func TestZoneTransfer(ctx context.Context, config dnsfern.EnumerateDnsZoneTransferConfig) (*dnsfern.EnumerateDnsZoneTransferReport, error) {
 	log := svc1log.FromContext(ctx)
 
+	customResolvers := []*net.Resolver{}
+	for _, dnsResolver := range config.DnsResolvers {
+		customResolvers = append(customResolvers, utils.GetResolver(dnsResolver, log))
+	}
+
 	// Direct nameserver mode
 	if config.Nameserver != nil && *config.Nameserver != "" {
 		log.Info("Using direct nameserver mode", svc1log.SafeParam("nameserver", *config.Nameserver))
-		return testDirectNameserver(ctx, config)
+		return testDirectNameserver(ctx, config, customResolvers)
 	}
 
 	// NS lookup mode
 	log.Info("Using NS lookup mode")
-	return testViaNSLookup(ctx, config)
+	return testViaNSLookup(ctx, config, customResolvers)
 }
 
 // testDirectNameserver tests zone transfers directly against a specified nameserver
-func testDirectNameserver(ctx context.Context, config dnsfern.EnumerateDnsZoneTransferConfig) (*dnsfern.EnumerateDnsZoneTransferReport, error) {
+func testDirectNameserver(ctx context.Context, config dnsfern.EnumerateDnsZoneTransferConfig, customResolvers []*net.Resolver) (*dnsfern.EnumerateDnsZoneTransferReport, error) {
 	log := svc1log.FromContext(ctx)
 	errors := []string{}
 	zoneTransferDetails := []*dnsfern.DnsZoneTransferDetails{}
 
-	// Get custom resolver if specified
-	customResolver := utils.GetResolver(*config.DnsResolver, log)
-
 	// Normalize nameserver address
 	ns := normalizeNameserver(*config.Nameserver)
 
+	roundRobinResolver := 0
 	for _, domain := range config.Domains {
 		log.Info("Testing zone transfer",
 			svc1log.SafeParam("domain", domain),
 			svc1log.SafeParam("nameserver", ns))
 
 		// Attempt zone transfer
-		records, success, errs := sendAXFRRequest(ns, domain, config.Timeout, customResolver, log)
-
+		records, success, errs := sendAXFRRequest(ns, domain, config.Timeout, customResolvers[roundRobinResolver%len(customResolvers)], log)
 		if len(errs) > 0 {
 			for _, err := range errs {
 				errors = append(errors, fmt.Sprintf("%s@%s: %s", domain, ns, err))
@@ -66,6 +68,7 @@ func testDirectNameserver(ctx context.Context, config dnsfern.EnumerateDnsZoneTr
 				svc1log.SafeParam("domain", domain),
 				svc1log.SafeParam("records", len(records)))
 		}
+		roundRobinResolver++
 	}
 	report := &dnsfern.EnumerateDnsZoneTransferReport{
 		Config: &config,
@@ -78,17 +81,16 @@ func testDirectNameserver(ctx context.Context, config dnsfern.EnumerateDnsZoneTr
 }
 
 // testViaNSLookup discovers nameservers and tests zone transfers on each
-func testViaNSLookup(ctx context.Context, config dnsfern.EnumerateDnsZoneTransferConfig) (*dnsfern.EnumerateDnsZoneTransferReport, error) {
+func testViaNSLookup(ctx context.Context, config dnsfern.EnumerateDnsZoneTransferConfig, customResolvers []*net.Resolver) (*dnsfern.EnumerateDnsZoneTransferReport, error) {
 	log := svc1log.FromContext(ctx)
 	errors := []string{}
 	zoneTransferDetails := []*dnsfern.DnsZoneTransferDetails{}
 
-	// Get custom resolver if specified
-	customResolver := utils.GetResolver(*config.DnsResolver, log)
-
+	roundRobinResolver := 0
 	for _, domain := range config.Domains {
-		details := testDomainViaLookup(ctx, domain, config.Timeout, customResolver, log, &errors)
+		details := testDomainViaLookup(ctx, domain, config.Timeout, customResolvers[roundRobinResolver%len(customResolvers)], log, &errors)
 		zoneTransferDetails = append(zoneTransferDetails, details)
+		roundRobinResolver++
 	}
 
 	report := &dnsfern.EnumerateDnsZoneTransferReport{


### PR DESCRIPTION
### TL;DR

Enhanced DNS resolver functionality by replacing single resolver with multiple resolvers support for zone transfer operations.

### What changed?

- Changed `--dns-resolver` flag to `--dns-resolvers` to support multiple DNS resolvers
- Modified the flag to accept a string slice instead of a single string
- Added validation for each resolver in the list
- Implemented round-robin selection of resolvers during zone transfer operations
- Updated configuration structure in the Fern definition to support multiple DNS resolvers
- Set default resolver to `1.1.1.1:53` if none is provided
- Added error handling when no DNS resolvers are provided
