### PR TITLE
Update CDN Logic to enable IP addresses to be passed in

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -459,7 +459,12 @@ func (a *OsintScan) InitDiscoverCommand() {
 		Long:  `Check if an IP address belongs to a known CDN provider by comparing against known CDN IP ranges.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			// Parse flags
-			domains, err := cmd.Flags().GetStringSlice("domains")
+			domain, err := cmd.Flags().GetString("domain")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			ipAddresses, err := cmd.Flags().GetStringSlice("ip-addresses")
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -487,7 +492,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 			}
 
 			// Create config
-			config := getDiscoverCdnConfig(domains, dnsResolvers, fingerprintsFile)
+			config := getDiscoverCdnConfig(domain, ipAddresses, dnsResolvers, fingerprintsFile)
 
 			// Create report
 			report := cdn.RunDiscoverCdns(cmd.Context(), config)
@@ -496,12 +501,13 @@ func (a *OsintScan) InitDiscoverCommand() {
 	}
 
 	// Target Flags
-	discoverCdnCmd.Flags().StringSlice("domains", []string{}, "The domain names to check against CDN provider ranges")
+	discoverCdnCmd.Flags().String("domain", "", "The domain name to check against CDN provider ranges")
+	discoverCdnCmd.Flags().StringSlice("ip-addresses", []string{}, "The IP addresses to check against CDN provider ranges")
 	discoverCdnCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
 	discoverCdnCmd.Flags().String("fingerprints-file", "/opt/method/osintscan/var/conf/discover/cdn/providers.json", "The path to the CDN fingerprints file")
 
 	// Mark Required Flags
-	_ = discoverCdnCmd.MarkFlagRequired("domains")
+	_ = discoverCdnCmd.MarkFlagRequired("domain")
 
 	// Add command to the 'discover' command
 	discoverCmd.AddCommand(discoverCdnCmd)
@@ -575,11 +581,14 @@ func getDiscoverDNSIntelligentSubdomainConfig(domains []string, threads int, tim
 }
 
 // getDiscoverCdnConfig creates and returns a configuration for CDN discovery
-func getDiscoverCdnConfig(domains []string, dnsResolvers []string, fingerprintsFile string) cdnfern.DiscoverCdnConfig {
-	return cdnfern.DiscoverCdnConfig{
-		Domains:          domains,
+func getDiscoverCdnConfig(domain string, ipAddresses []string, dnsResolvers []string, fingerprintsFile string) cdnfern.DiscoverCdnConfig {
+	config := cdnfern.DiscoverCdnConfig{
+		Domain:           domain,
 		DnsResolvers:     dnsResolvers,
 		FingerprintsFile: fingerprintsFile,
 	}
-
+	if len(ipAddresses) > 0 {
+		config.IpAddresses = ipAddresses
+	}
+	return config
 }

--- a/fern/definition/discover/cdn.yml
+++ b/fern/definition/discover/cdn.yml
@@ -18,7 +18,8 @@ types:
 # Report Config
   DiscoverCdnConfig:
     properties:
-      domains: list<string>
+      domain: string
+      ipAddresses: optional<list<string>>
       dnsResolvers: optional<list<string>>
       fingerprintsFile: string
 # Report Structs
@@ -33,7 +34,7 @@ types:
       match: CdnMatch
   DiscoverCdnResult:
     properties:
-      results: optional<list<IpCdnResult>>
+      matches: optional<list<IpCdnResult>>
   DiscoverCdnReport:
     properties:
       config: DiscoverCdnConfig

--- a/internal/discover/cdn.go
+++ b/internal/discover/cdn.go
@@ -26,7 +26,7 @@ func RunDiscoverCdns(ctx context.Context, config cdnfern.DiscoverCdnConfig) *cdn
 
 	// Initialize empty result structure to hold all IP check results
 	result := &cdnfern.DiscoverCdnResult{
-		Results: []*cdnfern.IpCdnResult{},
+		Matches: []*cdnfern.IpCdnResult{},
 	}
 
 	// Initialize report structure with config and result
@@ -42,49 +42,29 @@ func RunDiscoverCdns(ctx context.Context, config cdnfern.DiscoverCdnConfig) *cdn
 		return report
 	}
 
-	// Create resolvers for each provided DNS server
-	resolvers := []*net.Resolver{}
-	for _, dnsServerAddress := range config.DnsResolvers {
-		resolvers = append(resolvers, utils.GetResolver(dnsServerAddress, log))
-	}
+	// If no IP addresses are provided, resolve the domain to IP addresses else check the provided IP addresses
+	if config.IpAddresses == nil {
+		// Create resolvers for each provided DNS server
+		resolvers := []*net.Resolver{}
+		for _, dnsServerAddress := range config.DnsResolvers {
+			resolvers = append(resolvers, utils.GetResolver(dnsServerAddress, log))
+		}
 
-	// Iterate through each domain provided in the config
-	for _, domain := range config.Domains {
-		log.Info("Resolving domain", svc1log.SafeParam("domain", domain))
+		// Iterate through each domain provided in the config
+		log.Info("Resolving domain", svc1log.SafeParam("domain", config.Domain))
 
 		// Resolve domain to IP addresses using round-robin resolvers
-		ipAddresses, resolveErrors := resolvedomainToIPs(ctx, domain, resolvers, log)
-
-		// Add any resolution errors to the report
+		ipAddresses, resolveErrors := resolvedomainToIPs(ctx, config.Domain, resolvers, log)
 		report.Errors = append(report.Errors, resolveErrors...)
 
 		// Check each resolved IP address against CDN ranges
-		for _, ipAddress := range ipAddresses {
-			log.Info("Checking resolved IP address", svc1log.SafeParam("domain", domain), svc1log.SafeParam("ipAddress", ipAddress))
-
-			// Initialize result structure for this specific IP
-
-			// Parse and validate the IP address string
-			ip := net.ParseIP(strings.TrimSpace(ipAddress))
-			if ip == nil {
-				log.Error("Invalid IP address from resolution", svc1log.SafeParam("domain", domain), svc1log.SafeParam("ipAddress", ipAddress))
-				continue
-			}
-
-			// Check if this IP falls within any CDN provider ranges
-			match, errors := checkIPAgainstCdnRanges(ctx, ip, cdnFingerprints)
-			if match != nil {
-				ipResult := &cdnfern.IpCdnResult{
-					Domain:    domain,
-					IpAddress: ipAddress,
-					Match:     match,
-				}
-				result.Results = append(result.Results, ipResult)
-			}
-
-			// Accumulate any errors encountered during checking
-			report.Errors = append(report.Errors, errors...)
-		}
+		matches, errors := checkIPAgainstCdnRanges(ctx, ipAddresses, config, cdnFingerprints)
+		report.Errors = append(report.Errors, errors...)
+		result.Matches = append(result.Matches, matches...)
+	} else {
+		matches, errors := checkIPAgainstCdnRanges(ctx, config.IpAddresses, config, cdnFingerprints)
+		report.Errors = append(report.Errors, errors...)
+		result.Matches = append(result.Matches, matches...)
 	}
 
 	// Set final result and return complete report
@@ -110,9 +90,44 @@ func loadCdnDictFromPath(fingerprintsFile string) (*cdnfern.CdnProviders, error)
 	return &cfg, nil
 }
 
+func checkIPAgainstCdnRanges(ctx context.Context, ipAddresses []string, config cdnfern.DiscoverCdnConfig, cdnFingerprints *cdnfern.CdnProviders) (matches []*cdnfern.IpCdnResult, errors []string) {
+	log := svc1log.FromContext(ctx)
+
+	matches = []*cdnfern.IpCdnResult{}
+	errors = []string{}
+
+	for _, ipAddress := range ipAddresses {
+		log.Info("Checking IP address", svc1log.SafeParam("ipAddress", ipAddress))
+
+		// Initialize result structure for this specific IP
+
+		// Parse and validate the IP address string
+		ip := net.ParseIP(strings.TrimSpace(ipAddress))
+		if ip == nil {
+			log.Error("Invalid IP address from resolution", svc1log.SafeParam("domain", config.Domain), svc1log.SafeParam("ipAddress", ipAddress))
+			continue
+		}
+
+		// Check if this IP falls within any CDN provider ranges
+		match, errs := checkCdnRanges(ctx, ip, cdnFingerprints)
+		if match != nil {
+			ipResult := &cdnfern.IpCdnResult{
+				Domain:    config.Domain,
+				IpAddress: ipAddress,
+				Match:     match,
+			}
+			matches = append(matches, ipResult)
+		}
+
+		// Accumulate any errors encountered during checking
+		errors = append(errors, errs...)
+	}
+	return matches, errors
+}
+
 // checkIPAgainstCdnRanges compares an IP address against all CDN provider IP ranges
 // Returns the first matching CDN provider and any errors encountered
-func checkIPAgainstCdnRanges(ctx context.Context, ip net.IP, cdnFingerprints *cdnfern.CdnProviders) (*cdnfern.CdnMatch, []string) {
+func checkCdnRanges(ctx context.Context, ip net.IP, cdnFingerprints *cdnfern.CdnProviders) (*cdnfern.CdnMatch, []string) {
 	log := svc1log.FromContext(ctx)
 	errors := []string{}
 


### PR DESCRIPTION
### TL;DR

Updated the CDN discovery command to use a single domain parameter with optional IP addresses instead of multiple domains.

### What changed?

- Changed the CLI interface from accepting multiple domains via `--domains` to accepting a single domain via `--domain`
- Added a new `--ip-addresses` flag to allow direct checking of IP addresses against CDN ranges
- Refactored the `DiscoverCdnConfig` structure to reflect these changes
- Renamed `results` field to `matches` in the `DiscoverCdnResult` structure for better clarity
- Restructured the CDN checking logic to handle both domain resolution and direct IP checking paths
- Split the IP checking logic into separate functions for better code organization
