### PR TITLE
IP Discover and ASN Discover commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ osintscan discover dns records --domain example.com
 ```bash
 osintscan discover dns certs --domain example.com
 
+### Developer Setup
+
+`osintscan` uses [Fern](https://buildwithfern.com/learn/sdks/overview/introduction) for creating multi-language bindings. This is used for structuring input and output amongst tools.
+
+1. Install Fern: https://buildwithfern.com/learn/sdks/overview/quickstart
+
+2. Generate your fern types with:
+
+```bash
+fern generate --group local
+```
+
+3. Ensure depedencies are installed and tested with:
+
+```bash
+./godelw verify
+```
+
 ### Building a Statically Compiled Container for Local Testing
 (Reference reusable-build.yaml)
 

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -3,18 +3,22 @@ package cmd
 import (
 	// Standard
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
 	// Generated
 	cdnfern "github.com/Method-Security/osintscan/generated/go/discover"
+	asnfern "github.com/Method-Security/osintscan/generated/go/discover/asn"
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
+	ipfern "github.com/Method-Security/osintscan/generated/go/discover/ip"
 
 	// Internal
-	cdn "github.com/Method-Security/osintscan/internal/discover"
+	discover "github.com/Method-Security/osintscan/internal/discover"
 	dns "github.com/Method-Security/osintscan/internal/discover/dns"
 	subdomain "github.com/Method-Security/osintscan/internal/discover/dns/subdomain"
 	subdomainIntelligent "github.com/Method-Security/osintscan/internal/discover/dns/subdomain/intelligent"
+	ip "github.com/Method-Security/osintscan/internal/discover/ip"
 
 	// External
 	shodan "github.com/Method-Security/osintscan/internal/discover/shodan"
@@ -495,7 +499,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 			config := getDiscoverCdnConfig(domain, ipAddresses, dnsResolvers, fingerprintsFile)
 
 			// Create report
-			report := cdn.RunDiscoverCdns(cmd.Context(), config)
+			report := discover.RunDiscoverCdns(cmd.Context(), config)
 			a.OutputSignal.Content = report
 		},
 	}
@@ -512,6 +516,138 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Add command to the 'discover' command
 	discoverCmd.AddCommand(discoverCdnCmd)
 
+	// ------------------------------------------------------------------------------------------------
+	// Start - IP Address Discover Commands
+	// ------------------------------------------------------------------------------------------------
+
+	// IP Address Discover Commands
+	discoverIPCmd := &cobra.Command{
+		Use:   "ip",
+		Short: "Discover IP address and CIDR information",
+		Long:  `Discover information about IP addresses or CIDR Ranges including linked domains, ASN, geolocation.`,
+	}
+
+	// Add discoverIPCmd to the 'discover' command
+	discoverCmd.AddCommand(discoverIPCmd)
+
+	discoverIPDomainASNCmd := &cobra.Command{
+		Use:   "domainasn",
+		Short: "Perform a reverse DNS lookup and ASN lookup on a single IP, list of IPs, or a CIDR range",
+		Long:  `Perform a reverse DNS lookup and ASN lookup on a single IP, list of IPs, or a CIDR range. Warning: /16 and larger can take upwards of 30 minutes.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Parse flags
+			ips, err := cmd.Flags().GetStringSlice("ips")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			cidr, err := cmd.Flags().GetString("cidr")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Validate that either ip or cidr is provided
+			if len(ips) == 0 && cidr == "" {
+				a.OutputSignal.AddError(fmt.Errorf("either --ips or --cidr must be provided"))
+				return
+			}
+
+			// Validate IP addresses if provided
+			if len(ips) > 0 {
+				for _, ip := range ips {
+					if net.ParseIP(ip) == nil {
+						a.OutputSignal.AddError(fmt.Errorf("invalid IP address: %s", ip))
+						return
+					}
+				}
+			}
+
+			// Validate CIDR if provided
+			if cidr != "" {
+				if _, _, err := net.ParseCIDR(cidr); err != nil {
+					a.OutputSignal.AddError(fmt.Errorf("invalid CIDR range: %s", cidr))
+					return
+				}
+			}
+
+			// Validate DNS resolvers
+			if len(dnsResolvers) == 0 {
+				a.OutputSignal.AddError(fmt.Errorf("no DNS resolvers provided"))
+				return
+			}
+			for _, dnsResolver := range dnsResolvers {
+				err = utils.ValidateDNSServerAddress(dnsResolver)
+				if err != nil {
+					a.OutputSignal.AddError(fmt.Errorf("invalid DNS resolver: %w", err))
+					return
+				}
+			}
+
+			// Generate the report
+			config := getDiscoverIPDomainASNConfig(ips, cidr, dnsResolvers)
+			report := ip.GetDomainASNLookup(cmd.Context(), config)
+			a.OutputSignal.Content = report
+		},
+	}
+
+	// Target Flags
+	discoverIPDomainASNCmd.Flags().StringSlice("ips", []string{}, "The IP addresses to perform reverse DNS and ASN lookup on")
+	discoverIPDomainASNCmd.Flags().String("cidr", "", "The CIDR range to perform reverse DNS and ASN lookup on")
+	discoverIPDomainASNCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
+
+	// Add command to 'ip' command
+	discoverIPCmd.AddCommand(discoverIPDomainASNCmd)
+	// ------------------------------------------------------------------------------------------------
+	// End - IP Address Discover Commands
+	// ------------------------------------------------------------------------------------------------
+
+	// ------------------------------------------------------------------------------------------------
+	// Start - ASN Address Discover Commands
+	// ------------------------------------------------------------------------------------------------
+
+	// ASN Address Discover Commands
+	discoverASNCmd := &cobra.Command{
+		Use:   "asn",
+		Short: "Discover ASN information",
+		Long:  `Discover information about ASN, including ASN description, CIDRs, country, and other metadata. This relies on BGPView's API and has built in retry and timeout mechanisms.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			asnFlag, err := cmd.Flags().GetString("asn")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			config := getDiscoverASNConfig(asnFlag, timeout)
+			report, err := discover.GetASNInfo(cmd.Context(), config)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+
+	// Target Flags
+	discoverASNCmd.Flags().String("asn", "", "The ASN number to lookup (e.g., AS23028 or 23028)")
+	discoverASNCmd.Flags().Int("timeout", 120, "The timeout in seconds for the ASN lookup")
+
+	// Mark Required Flags
+	_ = discoverASNCmd.MarkFlagRequired("asn")
+
+	// Add command to 'discover' command
+	discoverCmd.AddCommand(discoverASNCmd)
+
+	// Add the 'discover' command to the root command
 	a.RootCmd.AddCommand(discoverCmd)
 }
 
@@ -591,4 +727,27 @@ func getDiscoverCdnConfig(domain string, ipAddresses []string, dnsResolvers []st
 		config.IpAddresses = ipAddresses
 	}
 	return config
+}
+
+// getDiscoverIPDomainASNConfig creates and returns a configuration for IP domain ASN discovery
+func getDiscoverIPDomainASNConfig(ips []string, cidr string, dnsResolvers []string) *ipfern.DiscoverIpDomainAsnConfig {
+	config := &ipfern.DiscoverIpDomainAsnConfig{
+		Ips:          ips,
+		DnsResolvers: dnsResolvers,
+	}
+
+	// Only set CIDR if it's not empty
+	if cidr != "" {
+		config.Cidr = &cidr
+	}
+
+	return config
+}
+
+// getDiscoverASNConfig creates and returns a configuration for ASN discovery
+func getDiscoverASNConfig(asn string, timeout int) *asnfern.DiscoverAsnConfig {
+	return &asnfern.DiscoverAsnConfig{
+		Asn:     asn,
+		Timeout: &timeout,
+	}
 }

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -516,10 +516,6 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Add command to the 'discover' command
 	discoverCmd.AddCommand(discoverCdnCmd)
 
-	// ------------------------------------------------------------------------------------------------
-	// Start - IP Address Discover Commands
-	// ------------------------------------------------------------------------------------------------
-
 	// IP Address Discover Commands
 	discoverIPCmd := &cobra.Command{
 		Use:   "ip",
@@ -531,7 +527,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverCmd.AddCommand(discoverIPCmd)
 
 	discoverIPDomainASNCmd := &cobra.Command{
-		Use:   "domainasn",
+		Use:   "domain-asn",
 		Short: "Perform a reverse DNS lookup and ASN lookup on a single IP, list of IPs, or a CIDR range",
 		Long:  `Perform a reverse DNS lookup and ASN lookup on a single IP, list of IPs, or a CIDR range. Warning: /16 and larger can take upwards of 30 minutes.`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -603,13 +599,6 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Add command to 'ip' command
 	discoverIPCmd.AddCommand(discoverIPDomainASNCmd)
-	// ------------------------------------------------------------------------------------------------
-	// End - IP Address Discover Commands
-	// ------------------------------------------------------------------------------------------------
-
-	// ------------------------------------------------------------------------------------------------
-	// Start - ASN Address Discover Commands
-	// ------------------------------------------------------------------------------------------------
 
 	// ASN Address Discover Commands
 	discoverASNCmd := &cobra.Command{

--- a/fern/definition/discover/asn/asn.yml
+++ b/fern/definition/discover/asn/asn.yml
@@ -4,8 +4,7 @@ types:
     properties:
       asn: string
       timeout: optional<integer>
-# Report Structs
-  DiscoverASNResult:
+  DiscoverASNLookup:
     properties:
       asn: string
       description: optional<string>
@@ -14,6 +13,10 @@ types:
       registry: optional<string>
       allocationDate: optional<string>
       allocationStatus: optional<string>
+# Report Structs
+  DiscoverASNResult:
+    properties:
+      lookup: optional<DiscoverASNLookup>
   DiscoverASNReport:
     properties:
       config: DiscoverASNConfig

--- a/fern/definition/discover/asn/asn.yml
+++ b/fern/definition/discover/asn/asn.yml
@@ -1,0 +1,21 @@
+types:
+# Config Struct
+  DiscoverASNConfig:
+    properties:
+      asn: string
+      timeout: optional<integer>
+# Report Structs
+  DiscoverASNResult:
+    properties:
+      asn: string
+      description: optional<string>
+      cidrs: optional<list<string>>
+      country: optional<string>
+      registry: optional<string>
+      allocationDate: optional<string>
+      allocationStatus: optional<string>
+  DiscoverASNReport:
+    properties:
+      config: DiscoverASNConfig
+      result: DiscoverASNResult
+      errors: optional<list<string>>

--- a/fern/definition/discover/ip/domainasn.yml
+++ b/fern/definition/discover/ip/domainasn.yml
@@ -1,0 +1,23 @@
+types:
+# Lookup Struct
+  LookupDetails:
+    properties:
+      ip: string
+      domain: optional<string>
+      asn: optional<string>
+      geolocation: optional<string>
+# Config Struct
+  DiscoverIPDomainASNConfig:
+    properties:
+      ips: optional<list<string>>
+      cidr: optional<string>
+      dnsResolvers: optional<list<string>>
+# Report Structs
+  DiscoverIPDomainASNResult:
+    properties:
+      lookups: optional<list<LookupDetails>>
+  DiscoverIPDomainASNReport:
+    properties:
+      config: DiscoverIPDomainASNConfig
+      result: DiscoverIPDomainASNResult
+      errors: optional<list<string>>

--- a/fern/definition/discover/ip/domainasn.yml
+++ b/fern/definition/discover/ip/domainasn.yml
@@ -5,7 +5,7 @@ types:
       ip: string
       domain: optional<string>
       asn: optional<string>
-      geolocation: optional<string>
+      geoLocation: optional<string>
 # Config Struct
   DiscoverIPDomainASNConfig:
     properties:

--- a/fern/definition/utils/bgpview.yml
+++ b/fern/definition/utils/bgpview.yml
@@ -1,0 +1,126 @@
+types:
+  BgpViewResponse:
+    docs: Top-level response from BgpView API
+    properties:
+      status:
+        type: string
+        docs: Status of the API response
+      status_message:
+        type: string
+        docs: Status message from the API
+      data:
+        type: optional<BgpViewData>
+        docs: Data section of the response
+      meta:
+        type: optional<BgpViewMeta>
+        docs: Metadata about the API response
+
+  BgpViewData:
+    docs: Data section of BgpView response containing ASN and prefix information
+    properties:
+      ipv4_prefixes:
+        type: list<BgpViewPrefix>
+        docs: List of IPv4 prefixes
+      ipv6_prefixes:
+        type: list<BgpViewPrefix>
+        docs: List of IPv6 prefixes
+      asn:
+        type: integer
+        docs: Autonomous System Number
+      name:
+        type: string
+        docs: Name of the ASN
+      description_short:
+        type: string
+        docs: Short description of the ASN
+      country_code:
+        type: string
+        docs: Country code for the ASN
+      website:
+        type: string
+        docs: Website associated with the ASN
+      email_contacts:
+        type: list<string>
+        docs: List of email contacts
+      abuse_contacts:
+        type: list<string>
+        docs: List of abuse contacts
+      rir_allocation:
+        type: optional<BgpViewRirAllocation>
+        docs: Rir allocation information
+
+  BgpViewPrefix:
+    docs: Bgp prefix information from BgpView API
+    properties:
+      prefix:
+        type: string
+        docs: The IP prefix
+      ip:
+        type: string
+        docs: The IP address
+      cidr:
+        type: integer
+        docs: CIDR notation length
+      roa_status:
+        type: string
+        docs: Route Origin Authorization status
+      name:
+        type: string
+        docs: Name of the prefix
+      description:
+        type: string
+        docs: Description of the prefix
+      country_code:
+        type: string
+        docs: Country code for the prefix
+      parent:
+        type: optional<BgpViewPrefixParent>
+        docs: Parent prefix information
+
+  BgpViewPrefixParent:
+    docs: Parent prefix information
+    properties:
+      prefix:
+        type: string
+        docs: Parent prefix
+      ip:
+        type: string
+        docs: Parent IP address
+      cidr:
+        type: integer
+        docs: Parent CIDR notation length
+      rir_name:
+        type: string
+        docs: Rir name for the parent
+      allocation_status:
+        type: string
+        docs: Allocation status of the parent
+
+  BgpViewRirAllocation:
+    docs: Rir allocation information
+    properties:
+      rir_name:
+        type: string
+        docs: Name of the Regional Internet Registry
+      country_code:
+        type: string
+        docs: Country code for the allocation
+      date_allocated:
+        type: string
+        docs: Date when the allocation was made
+      allocation_status:
+        type: string
+        docs: Status of the allocation
+
+  BgpViewMeta:
+    docs: Metadata from BgpView API
+    properties:
+      time_zone:
+        type: string
+        docs: Time zone information
+      api_version:
+        type: integer
+        docs: API version number
+      execution_time:
+        type: string
+        docs: Execution time of the API call

--- a/fern/definition/utils/cymru.yml
+++ b/fern/definition/utils/cymru.yml
@@ -1,0 +1,19 @@
+types:
+  CymruASNResult:
+    docs: Represents the parsed result from a Cymru ASN lookup
+    properties:
+      asn:
+        type: string
+        docs: The Autonomous System Number
+      bgpPrefix:
+        type: string
+        docs: The BGP prefix associated with the ASN
+      countryCode:
+        type: string
+        docs: The country code where the ASN is registered
+      registry:
+        type: string
+        docs: The registry that allocated the ASN
+      allocDate:
+        type: string
+        docs: The date when the ASN was allocated

--- a/internal/discover/asn.go
+++ b/internal/discover/asn.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	asnfern "github.com/Method-Security/osintscan/generated/go/discover/asn"
+	utilsfern "github.com/Method-Security/osintscan/generated/go/utils"
 	"github.com/Method-Security/osintscan/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
@@ -29,7 +30,7 @@ func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfer
 	}
 
 	// Get comprehensive ASN information from BGPView API
-	var bgpInfo *utils.BGPViewResponse
+	var bgpInfo *utilsfern.BgpViewResponse
 	var err error
 
 	if timeout > 0 {
@@ -43,9 +44,9 @@ func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfer
 		errors = append(errors, "Failed to get ASN information: "+err.Error())
 	} else if bgpInfo != nil && bgpInfo.Data != nil {
 		// Extract description from BGPView response
-		if bgpInfo.Data.Description != "" {
-			lookup.Description = &bgpInfo.Data.Description
-			log.Debug("Retrieved ASN description from BGPView", svc1log.SafeParam("description", bgpInfo.Data.Description))
+		if bgpInfo.Data.DescriptionShort != "" {
+			lookup.Description = &bgpInfo.Data.DescriptionShort
+			log.Debug("Retrieved ASN description from BGPView", svc1log.SafeParam("description", bgpInfo.Data.DescriptionShort))
 		} else if bgpInfo.Data.Name != "" {
 			// Fallback to name if description is empty
 			lookup.Description = &bgpInfo.Data.Name
@@ -58,23 +59,23 @@ func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfer
 		}
 
 		// Extract registry and allocation information from RIR allocation
-		if bgpInfo.Data.RIRAllocation != nil {
-			if bgpInfo.Data.RIRAllocation.RIRName != "" {
-				lookup.Registry = &bgpInfo.Data.RIRAllocation.RIRName
+		if bgpInfo.Data.RirAllocation != nil {
+			if bgpInfo.Data.RirAllocation.RirName != "" {
+				lookup.Registry = &bgpInfo.Data.RirAllocation.RirName
 			}
-			if bgpInfo.Data.RIRAllocation.DateAllocated != "" {
-				lookup.AllocationDate = &bgpInfo.Data.RIRAllocation.DateAllocated
+			if bgpInfo.Data.RirAllocation.DateAllocated != "" {
+				lookup.AllocationDate = &bgpInfo.Data.RirAllocation.DateAllocated
 			}
-			if bgpInfo.Data.RIRAllocation.AllocationStatus != "" {
-				lookup.AllocationStatus = &bgpInfo.Data.RIRAllocation.AllocationStatus
+			if bgpInfo.Data.RirAllocation.AllocationStatus != "" {
+				lookup.AllocationStatus = &bgpInfo.Data.RirAllocation.AllocationStatus
 			}
 		}
 
 		log.Debug("Retrieved ASN metadata from BGPView",
 			svc1log.SafeParam("country", bgpInfo.Data.CountryCode),
 			svc1log.SafeParam("registry", func() string {
-				if bgpInfo.Data.RIRAllocation != nil {
-					return bgpInfo.Data.RIRAllocation.RIRName
+				if bgpInfo.Data.RirAllocation != nil {
+					return bgpInfo.Data.RirAllocation.RirName
 				}
 				return ""
 			}()))

--- a/internal/discover/asn.go
+++ b/internal/discover/asn.go
@@ -16,8 +16,8 @@ func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfer
 
 	log.Info("Starting ASN information lookup via BGPView", svc1log.SafeParam("asn", config.Asn))
 
-	// Initialize result with the input ASN
-	result := &asnfern.DiscoverAsnResult{
+	// Initialize lookup with the input ASN
+	lookup := &asnfern.DiscoverAsnLookup{
 		Asn: config.Asn,
 	}
 
@@ -44,29 +44,29 @@ func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfer
 	} else if bgpInfo != nil && bgpInfo.Data != nil {
 		// Extract description from BGPView response
 		if bgpInfo.Data.Description != "" {
-			result.Description = &bgpInfo.Data.Description
+			lookup.Description = &bgpInfo.Data.Description
 			log.Debug("Retrieved ASN description from BGPView", svc1log.SafeParam("description", bgpInfo.Data.Description))
 		} else if bgpInfo.Data.Name != "" {
 			// Fallback to name if description is empty
-			result.Description = &bgpInfo.Data.Name
+			lookup.Description = &bgpInfo.Data.Name
 			log.Debug("Retrieved ASN name from BGPView", svc1log.SafeParam("name", bgpInfo.Data.Name))
 		}
 
 		// Extract country code from BGPView response
 		if bgpInfo.Data.CountryCode != "" {
-			result.Country = &bgpInfo.Data.CountryCode
+			lookup.Country = &bgpInfo.Data.CountryCode
 		}
 
 		// Extract registry and allocation information from RIR allocation
 		if bgpInfo.Data.RIRAllocation != nil {
 			if bgpInfo.Data.RIRAllocation.RIRName != "" {
-				result.Registry = &bgpInfo.Data.RIRAllocation.RIRName
+				lookup.Registry = &bgpInfo.Data.RIRAllocation.RIRName
 			}
 			if bgpInfo.Data.RIRAllocation.DateAllocated != "" {
-				result.AllocationDate = &bgpInfo.Data.RIRAllocation.DateAllocated
+				lookup.AllocationDate = &bgpInfo.Data.RIRAllocation.DateAllocated
 			}
 			if bgpInfo.Data.RIRAllocation.AllocationStatus != "" {
-				result.AllocationStatus = &bgpInfo.Data.RIRAllocation.AllocationStatus
+				lookup.AllocationStatus = &bgpInfo.Data.RIRAllocation.AllocationStatus
 			}
 		}
 
@@ -92,13 +92,15 @@ func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfer
 		log.Warn("Failed to get ASN CIDRs from BGPView", svc1log.SafeParam("asn", config.Asn), svc1log.SafeParam("error", err.Error()))
 		errors = append(errors, "Failed to get ASN CIDRs: "+err.Error())
 	} else if len(cidrs) > 0 {
-		result.Cidrs = cidrs
+		lookup.Cidrs = cidrs
 		log.Debug("Retrieved ASN CIDRs from BGPView", svc1log.SafeParam("cidr_count", len(cidrs)))
 	}
 
 	report := &asnfern.DiscoverAsnReport{
 		Config: config,
-		Result: result,
+		Result: &asnfern.DiscoverAsnResult{
+			Lookup: lookup,
+		},
 	}
 
 	if len(errors) > 0 {
@@ -107,10 +109,10 @@ func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfer
 
 	log.Info("Completed ASN information lookup via BGPView",
 		svc1log.SafeParam("asn", config.Asn),
-		svc1log.SafeParam("has_description", result.Description != nil),
-		svc1log.SafeParam("has_country", result.Country != nil),
-		svc1log.SafeParam("has_registry", result.Registry != nil),
-		svc1log.SafeParam("cidr_count", len(result.Cidrs)),
+		svc1log.SafeParam("has_description", lookup.Description != nil),
+		svc1log.SafeParam("has_country", lookup.Country != nil),
+		svc1log.SafeParam("has_registry", lookup.Registry != nil),
+		svc1log.SafeParam("cidr_count", len(lookup.Cidrs)),
 		svc1log.SafeParam("error_count", len(errors)))
 
 	return report, nil

--- a/internal/discover/asn.go
+++ b/internal/discover/asn.go
@@ -1,0 +1,117 @@
+package discover
+
+import (
+	"context"
+	"time"
+
+	asnfern "github.com/Method-Security/osintscan/generated/go/discover/asn"
+	"github.com/Method-Security/osintscan/utils"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// GetASNInfo performs comprehensive ASN information lookup using only BGPView API
+func GetASNInfo(ctx context.Context, config *asnfern.DiscoverAsnConfig) (*asnfern.DiscoverAsnReport, error) {
+	log := svc1log.FromContext(ctx)
+	errors := []string{}
+
+	log.Info("Starting ASN information lookup via BGPView", svc1log.SafeParam("asn", config.Asn))
+
+	// Initialize result with the input ASN
+	result := &asnfern.DiscoverAsnResult{
+		Asn: config.Asn,
+	}
+
+	// Determine timeout duration
+	var timeout time.Duration
+	if config.Timeout != nil {
+		timeout = time.Duration(*config.Timeout) * time.Second
+		log.Debug("Using timeout for ASN lookup", svc1log.SafeParam("timeout_seconds", *config.Timeout))
+	}
+
+	// Get comprehensive ASN information from BGPView API
+	var bgpInfo *utils.BGPViewResponse
+	var err error
+
+	if timeout > 0 {
+		bgpInfo, err = utils.GetASNInfoWithTimeout(ctx, config.Asn, timeout)
+	} else {
+		bgpInfo, err = utils.GetASNInfo(ctx, config.Asn)
+	}
+
+	if err != nil {
+		log.Warn("Failed to get ASN info from BGPView", svc1log.SafeParam("asn", config.Asn), svc1log.SafeParam("error", err.Error()))
+		errors = append(errors, "Failed to get ASN information: "+err.Error())
+	} else if bgpInfo != nil && bgpInfo.Data != nil {
+		// Extract description from BGPView response
+		if bgpInfo.Data.Description != "" {
+			result.Description = &bgpInfo.Data.Description
+			log.Debug("Retrieved ASN description from BGPView", svc1log.SafeParam("description", bgpInfo.Data.Description))
+		} else if bgpInfo.Data.Name != "" {
+			// Fallback to name if description is empty
+			result.Description = &bgpInfo.Data.Name
+			log.Debug("Retrieved ASN name from BGPView", svc1log.SafeParam("name", bgpInfo.Data.Name))
+		}
+
+		// Extract country code from BGPView response
+		if bgpInfo.Data.CountryCode != "" {
+			result.Country = &bgpInfo.Data.CountryCode
+		}
+
+		// Extract registry and allocation information from RIR allocation
+		if bgpInfo.Data.RIRAllocation != nil {
+			if bgpInfo.Data.RIRAllocation.RIRName != "" {
+				result.Registry = &bgpInfo.Data.RIRAllocation.RIRName
+			}
+			if bgpInfo.Data.RIRAllocation.DateAllocated != "" {
+				result.AllocationDate = &bgpInfo.Data.RIRAllocation.DateAllocated
+			}
+			if bgpInfo.Data.RIRAllocation.AllocationStatus != "" {
+				result.AllocationStatus = &bgpInfo.Data.RIRAllocation.AllocationStatus
+			}
+		}
+
+		log.Debug("Retrieved ASN metadata from BGPView",
+			svc1log.SafeParam("country", bgpInfo.Data.CountryCode),
+			svc1log.SafeParam("registry", func() string {
+				if bgpInfo.Data.RIRAllocation != nil {
+					return bgpInfo.Data.RIRAllocation.RIRName
+				}
+				return ""
+			}()))
+	}
+
+	// Get CIDR prefixes from BGPView API
+	var cidrs []string
+	if timeout > 0 {
+		cidrs, err = utils.GetASNCIDRsWithTimeout(ctx, config.Asn, timeout)
+	} else {
+		cidrs, err = utils.GetASNCIDRs(ctx, config.Asn)
+	}
+
+	if err != nil {
+		log.Warn("Failed to get ASN CIDRs from BGPView", svc1log.SafeParam("asn", config.Asn), svc1log.SafeParam("error", err.Error()))
+		errors = append(errors, "Failed to get ASN CIDRs: "+err.Error())
+	} else if len(cidrs) > 0 {
+		result.Cidrs = cidrs
+		log.Debug("Retrieved ASN CIDRs from BGPView", svc1log.SafeParam("cidr_count", len(cidrs)))
+	}
+
+	report := &asnfern.DiscoverAsnReport{
+		Config: config,
+		Result: result,
+	}
+
+	if len(errors) > 0 {
+		report.Errors = errors
+	}
+
+	log.Info("Completed ASN information lookup via BGPView",
+		svc1log.SafeParam("asn", config.Asn),
+		svc1log.SafeParam("has_description", result.Description != nil),
+		svc1log.SafeParam("has_country", result.Country != nil),
+		svc1log.SafeParam("has_registry", result.Registry != nil),
+		svc1log.SafeParam("cidr_count", len(result.Cidrs)),
+		svc1log.SafeParam("error_count", len(errors)))
+
+	return report, nil
+}

--- a/internal/discover/ip/domainasn.go
+++ b/internal/discover/ip/domainasn.go
@@ -1,0 +1,196 @@
+package ip
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	ipfern "github.com/Method-Security/osintscan/generated/go/discover/ip"
+	"github.com/Method-Security/osintscan/utils"
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// GetDomainASNLookup performs reverse DNS and ASN lookups for IP addresses or CIDR ranges
+func GetDomainASNLookup(ctx context.Context, config *ipfern.DiscoverIpDomainAsnConfig) *ipfern.DiscoverIpDomainAsnReport {
+	log := svc1log.FromContext(ctx)
+	errors := []string{}
+
+	// Collect all IPs to process
+	allIPs, err := explodeIPsFromConfig(config)
+	if err != nil {
+		errors = append(errors, err.Error())
+		return &ipfern.DiscoverIpDomainAsnReport{
+			Config: config,
+			Result: &ipfern.DiscoverIpDomainAsnResult{},
+			Errors: errors,
+		}
+	}
+
+	log.Info("Starting IP domain/ASN lookup", svc1log.SafeParam("total_ips", len(allIPs)))
+
+	// Perform concurrent lookups
+	lookups, lookupErrors := performConcurrentLookups(ctx, allIPs, config.DnsResolvers)
+	if len(lookupErrors) > 0 {
+		errors = append(errors, lookupErrors...)
+	}
+
+	result := &ipfern.DiscoverIpDomainAsnResult{
+		Lookups: lookups,
+	}
+
+	return &ipfern.DiscoverIpDomainAsnReport{
+		Config: config,
+		Result: result,
+		Errors: errors,
+	}
+}
+
+// explodeIPsFromConfig extracts and expands all IPs from the configuration
+func explodeIPsFromConfig(config *ipfern.DiscoverIpDomainAsnConfig) ([]string, error) {
+	allIPs := []string{}
+
+	// Add individual IPs
+	if config.Ips != nil {
+		for _, ip := range config.Ips {
+			if net.ParseIP(ip) == nil {
+				return nil, fmt.Errorf("invalid IP address: %s", ip)
+			}
+			allIPs = append(allIPs, ip)
+		}
+	}
+
+	// Add CIDR range IPs
+	if config.Cidr != nil && *config.Cidr != "" {
+		cidrIPs, err := expandCIDR(*config.Cidr)
+		if err != nil {
+			return nil, fmt.Errorf("error expanding CIDR %s: %w", *config.Cidr, err)
+		}
+		allIPs = append(allIPs, cidrIPs...)
+	}
+
+	return allIPs, nil
+}
+
+// expandCIDR expands a CIDR range into individual IP addresses
+func expandCIDR(cidr string) ([]string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []string
+	for ip := ipNet.IP.Mask(ipNet.Mask); ipNet.Contains(ip); incrementIP(ip) {
+		ips = append(ips, ip.String())
+	}
+
+	return ips, nil
+}
+
+// incrementIP increments an IP address by 1
+func incrementIP(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
+
+// performConcurrentLookups performs reverse DNS and ASN lookups concurrently
+func performConcurrentLookups(ctx context.Context, ips []string, dnsResolvers []string) ([]*ipfern.LookupDetails, []string) {
+	log := svc1log.FromContext(ctx)
+	const maxWorkers = 50 // Limit concurrency to avoid overwhelming resolvers
+
+	lookups := make([]*ipfern.LookupDetails, 0, len(ips))
+	errors := []string{}
+	lookupsMutex := &sync.Mutex{}
+
+	semaphore := make(chan struct{}, maxWorkers)
+	var wg sync.WaitGroup
+	var completedCount int64
+	var resolverIndex int64
+
+	// Create resolvers
+	resolvers := make([]*net.Resolver, len(dnsResolvers))
+	for i, dnsResolver := range dnsResolvers {
+		resolvers[i] = utils.GetResolver(dnsResolver, log)
+	}
+
+	for _, ip := range ips {
+		wg.Add(1)
+
+		go func(ip string) {
+			defer wg.Done()
+
+			select {
+			case semaphore <- struct{}{}:
+				defer func() { <-semaphore }()
+			case <-ctx.Done():
+				return
+			}
+
+			// Use round robin for resolver selection
+			currentIndex := atomic.AddInt64(&resolverIndex, 1) - 1
+			resolverIdx := currentIndex % int64(len(resolvers))
+			resolver := resolvers[resolverIdx]
+
+			// Perform lookups
+			lookup := performSingleLookup(ctx, ip, resolver)
+			completed := atomic.AddInt64(&completedCount, 1)
+
+			if completed%100 == 0 || completed == int64(len(ips)) {
+				log.Info("Lookup progress",
+					svc1log.SafeParam("completed", completed),
+					svc1log.SafeParam("total", len(ips)))
+			}
+
+			lookupsMutex.Lock()
+			lookups = append(lookups, lookup)
+			lookupsMutex.Unlock()
+		}(ip)
+	}
+
+	wg.Wait()
+	return lookups, errors
+}
+
+// performSingleLookup performs reverse DNS and ASN lookup for a single IP
+func performSingleLookup(ctx context.Context, ip string, resolver *net.Resolver) *ipfern.LookupDetails {
+	lookup := &ipfern.LookupDetails{
+		Ip: ip,
+	}
+
+	// Perform reverse DNS lookup
+	if domain := performReverseDNSLookup(ctx, ip, resolver); domain != "" {
+		lookup.Domain = &domain
+	}
+
+	// Perform ASN lookup using whois
+	if asn := performASNLookup(ctx, ip); asn != "" {
+		lookup.Asn = &asn
+	}
+
+	return lookup
+}
+
+// performReverseDNSLookup performs reverse DNS lookup for an IP
+func performReverseDNSLookup(ctx context.Context, ip string, resolver *net.Resolver) string {
+	names, err := resolver.LookupAddr(ctx, ip)
+	if err != nil || len(names) == 0 {
+		return ""
+	}
+	// Return the first hostname found
+	return names[0]
+}
+
+// performASNLookup performs ASN lookup using Cymru DNS service
+func performASNLookup(ctx context.Context, ip string) string {
+	// Use Cymru DNS service with fallback to whois
+	asn, err := utils.IPASNLookupWithFallback(ctx, ip)
+	if err != nil {
+		return ""
+	}
+	return asn
+}

--- a/utils/bgpview.go
+++ b/utils/bgpview.go
@@ -1,0 +1,535 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// BGPView offers quality ASN and CIDR information particularly for ASN info lookups
+
+// BGPViewClient represents a client for the BGPView.io API
+type BGPViewClient struct {
+	baseURL    string
+	httpClient *http.Client
+	userAgent  string
+}
+
+// BGPViewResponse represents the top-level response from BGPView API
+type BGPViewResponse struct {
+	Status        string       `json:"status"`
+	StatusMessage string       `json:"status_message"`
+	Data          *BGPViewData `json:"data"`
+	Meta          *BGPViewMeta `json:"@meta"`
+}
+
+// BGPViewData represents the data section of BGPView response
+type BGPViewData struct {
+	IPv4Prefixes []BGPViewPrefix `json:"ipv4_prefixes"`
+	IPv6Prefixes []BGPViewPrefix `json:"ipv6_prefixes"`
+	// ASN Info fields
+	ASN           int                   `json:"asn"`
+	Name          string                `json:"name"`
+	Description   string                `json:"description_short"`
+	CountryCode   string                `json:"country_code"`
+	Website       string                `json:"website"`
+	EmailContacts []string              `json:"email_contacts"`
+	AbuseContacts []string              `json:"abuse_contacts"`
+	RIRAllocation *BGPViewRIRAllocation `json:"rir_allocation"`
+}
+
+// BGPViewPrefix represents a BGP prefix from BGPView API
+type BGPViewPrefix struct {
+	Prefix      string               `json:"prefix"`
+	IP          string               `json:"ip"`
+	CIDR        int                  `json:"cidr"`
+	ROAStatus   string               `json:"roa_status"`
+	Name        string               `json:"name"`
+	Description string               `json:"description"`
+	CountryCode string               `json:"country_code"`
+	Parent      *BGPViewPrefixParent `json:"parent"`
+}
+
+// BGPViewPrefixParent represents parent prefix information
+type BGPViewPrefixParent struct {
+	Prefix           string `json:"prefix"`
+	IP               string `json:"ip"`
+	CIDR             int    `json:"cidr"`
+	RIRName          string `json:"rir_name"`
+	AllocationStatus string `json:"allocation_status"`
+}
+
+// BGPViewRIRAllocation represents RIR allocation information
+type BGPViewRIRAllocation struct {
+	RIRName          string `json:"rir_name"`
+	CountryCode      string `json:"country_code"`
+	DateAllocated    string `json:"date_allocated"`
+	AllocationStatus string `json:"allocation_status"`
+}
+
+// BGPViewMeta represents metadata from BGPView API
+type BGPViewMeta struct {
+	TimeZone      string `json:"time_zone"`
+	APIVersion    int    `json:"api_version"`
+	ExecutionTime string `json:"execution_time"`
+}
+
+// NewBGPViewClient creates a new BGPView API client
+func NewBGPViewClient() *BGPViewClient {
+	// Initialize random seed for backoff calculations
+	rand.Seed(time.Now().UnixNano())
+
+	return &BGPViewClient{
+		baseURL: "https://api.bgpview.io",
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		userAgent: "osintscan/1.0 (https://github.com/Method-Security/osintscan)",
+	}
+}
+
+// SetTimeout sets the HTTP client timeout
+func (c *BGPViewClient) SetTimeout(timeout time.Duration) *BGPViewClient {
+	c.httpClient.Timeout = timeout
+	return c
+}
+
+// SetUserAgent sets a custom User-Agent header
+func (c *BGPViewClient) SetUserAgent(userAgent string) *BGPViewClient {
+	c.userAgent = userAgent
+	return c
+}
+
+// makeRequestWithRetry makes an HTTP request with retry logic for 429 responses
+func (c *BGPViewClient) makeRequestWithRetry(ctx context.Context, url string, timeout time.Duration) (*http.Response, error) {
+	log := svc1log.FromContext(ctx)
+	startTime := time.Now()
+
+	// If timeout is specified, create a context with timeout
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	for attempt := 1; ; attempt++ {
+		// Check if context is cancelled
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("request cancelled: %w", ctx.Err())
+		default:
+		}
+
+		// Create request with context
+		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+
+		// Set headers
+		req.Header.Set("User-Agent", c.userAgent)
+		req.Header.Set("Accept", "application/json")
+
+		// Make the request
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make HTTP request to BGPView API: %w", err)
+		}
+
+		// If we get a 429, implement retry logic
+		if resp.StatusCode == http.StatusTooManyRequests {
+			_ = resp.Body.Close() // Explicitly ignore close error for retry logic
+
+			// Check if we've exceeded the timeout
+			if timeout > 0 && time.Since(startTime) >= timeout {
+				return nil, fmt.Errorf("timeout exceeded after %v while retrying 429 responses", timeout)
+			}
+
+			// Calculate random backoff between 10-60 seconds
+			backoff := time.Duration(10+rand.Intn(51)) * time.Second
+
+			log.Warn("Received 429 from BGPView API, retrying with backoff",
+				svc1log.SafeParam("attempt", attempt),
+				svc1log.SafeParam("backoff_seconds", backoff.Seconds()),
+				svc1log.SafeParam("elapsed_time", time.Since(startTime).String()))
+
+			// Wait for the backoff period
+			select {
+			case <-time.After(backoff):
+				continue
+			case <-ctx.Done():
+				return nil, fmt.Errorf("request cancelled during backoff: %w", ctx.Err())
+			}
+		}
+
+		// For any other status code, return the response (let caller handle it)
+		return resp, nil
+	}
+}
+
+// GetASNPrefixes retrieves all BGP prefixes for a given ASN
+func (c *BGPViewClient) GetASNPrefixes(ctx context.Context, asn string) (*BGPViewResponse, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Normalize ASN format for API call
+	normalizedASN := normalizeASNForAPI(asn)
+
+	url := fmt.Sprintf("%s/asn/%s/prefixes", c.baseURL, normalizedASN)
+	log.Debug("Making BGPView API request", svc1log.SafeParam("url", url), svc1log.SafeParam("asn", normalizedASN))
+
+	// Use the retry logic
+	resp, err := c.makeRequestWithRetry(ctx, url, 0) // No timeout for this method
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("received nil response from BGPView API")
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warn("Failed to close response body", svc1log.SafeParam("error", closeErr.Error()))
+		}
+	}()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("BGPView API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Parse JSON response
+	var bgpResponse BGPViewResponse
+	if err := json.Unmarshal(body, &bgpResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	// Check API status
+	if bgpResponse.Status != "ok" {
+		return nil, fmt.Errorf("BGPView API error: %s", bgpResponse.StatusMessage)
+	}
+
+	log.Debug("BGPView API response received",
+		svc1log.SafeParam("ipv4_prefixes", len(bgpResponse.Data.IPv4Prefixes)),
+		svc1log.SafeParam("ipv6_prefixes", len(bgpResponse.Data.IPv6Prefixes)),
+		svc1log.SafeParam("execution_time", bgpResponse.Meta.ExecutionTime))
+
+	return &bgpResponse, nil
+}
+
+// GetASNCIDRs retrieves all CIDR prefixes for a given ASN using BGPView API
+// This is the main function called by the ASN discovery module
+func GetASNCIDRs(ctx context.Context, asn string) ([]string, error) {
+	log := svc1log.FromContext(ctx)
+
+	client := NewBGPViewClient()
+
+	log.Info("Retrieving ASN CIDRs from BGPView", svc1log.SafeParam("asn", asn))
+
+	response, err := client.GetASNPrefixes(ctx, asn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ASN prefixes from BGPView: %w", err)
+	}
+
+	if response.Data == nil {
+		return nil, fmt.Errorf("no data returned from BGPView API")
+	}
+
+	// Extract CIDRs from both IPv4 and IPv6 prefixes
+	var cidrs []string
+
+	// Add IPv4 prefixes
+	for _, prefix := range response.Data.IPv4Prefixes {
+		if prefix.Prefix != "" {
+			cidrs = append(cidrs, prefix.Prefix)
+		}
+	}
+
+	// Add IPv6 prefixes
+	for _, prefix := range response.Data.IPv6Prefixes {
+		if prefix.Prefix != "" {
+			cidrs = append(cidrs, prefix.Prefix)
+		}
+	}
+
+	log.Info("Retrieved ASN CIDRs from BGPView",
+		svc1log.SafeParam("asn", asn),
+		svc1log.SafeParam("total_cidrs", len(cidrs)),
+		svc1log.SafeParam("ipv4_cidrs", len(response.Data.IPv4Prefixes)),
+		svc1log.SafeParam("ipv6_cidrs", len(response.Data.IPv6Prefixes)))
+
+	return cidrs, nil
+}
+
+// GetASNCIDRsWithTimeout retrieves all CIDR prefixes for a given ASN using BGPView API with timeout
+func GetASNCIDRsWithTimeout(ctx context.Context, asn string, timeout time.Duration) ([]string, error) {
+	log := svc1log.FromContext(ctx)
+
+	client := NewBGPViewClient()
+
+	log.Info("Retrieving ASN CIDRs from BGPView with timeout",
+		svc1log.SafeParam("asn", asn),
+		svc1log.SafeParam("timeout", timeout.String()))
+
+	response, err := client.GetASNPrefixesWithTimeout(ctx, asn, timeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ASN prefixes from BGPView: %w", err)
+	}
+
+	if response.Data == nil {
+		return nil, fmt.Errorf("no data returned from BGPView API")
+	}
+
+	// Extract CIDRs from both IPv4 and IPv6 prefixes
+	var cidrs []string
+
+	// Add IPv4 prefixes
+	for _, prefix := range response.Data.IPv4Prefixes {
+		if prefix.Prefix != "" {
+			cidrs = append(cidrs, prefix.Prefix)
+		}
+	}
+
+	// Add IPv6 prefixes
+	for _, prefix := range response.Data.IPv6Prefixes {
+		if prefix.Prefix != "" {
+			cidrs = append(cidrs, prefix.Prefix)
+		}
+	}
+
+	log.Info("Retrieved ASN CIDRs from BGPView",
+		svc1log.SafeParam("asn", asn),
+		svc1log.SafeParam("total_cidrs", len(cidrs)),
+		svc1log.SafeParam("ipv4_cidrs", len(response.Data.IPv4Prefixes)),
+		svc1log.SafeParam("ipv6_cidrs", len(response.Data.IPv6Prefixes)))
+
+	return cidrs, nil
+}
+
+// GetASNCIDRsDetailed retrieves detailed CIDR information for a given ASN
+// Returns the full BGPView response with additional metadata
+func GetASNCIDRsDetailed(ctx context.Context, asn string) (*BGPViewResponse, error) {
+	client := NewBGPViewClient()
+	return client.GetASNPrefixes(ctx, asn)
+}
+
+// normalizeASNForAPI normalizes ASN format for BGPView API calls
+// BGPView expects format like "AS23028"
+func normalizeASNForAPI(asn string) string {
+	// Remove whitespace and convert to uppercase
+	normalized := strings.TrimSpace(strings.ToUpper(asn))
+
+	// If it doesn't start with AS, add it
+	if !strings.HasPrefix(normalized, "AS") {
+		normalized = "AS" + normalized
+	}
+
+	return normalized
+}
+
+// ExtractCIDRsByCountry filters CIDRs by country code from BGPView response
+func ExtractCIDRsByCountry(response *BGPViewResponse, countryCode string) []string {
+	if response == nil || response.Data == nil {
+		return nil
+	}
+
+	var cidrs []string
+	countryCode = strings.ToUpper(strings.TrimSpace(countryCode))
+
+	// Filter IPv4 prefixes by country
+	for _, prefix := range response.Data.IPv4Prefixes {
+		if strings.ToUpper(prefix.CountryCode) == countryCode {
+			cidrs = append(cidrs, prefix.Prefix)
+		}
+	}
+
+	// Filter IPv6 prefixes by country
+	for _, prefix := range response.Data.IPv6Prefixes {
+		if strings.ToUpper(prefix.CountryCode) == countryCode {
+			cidrs = append(cidrs, prefix.Prefix)
+		}
+	}
+
+	return cidrs
+}
+
+// GetASNInfo retrieves comprehensive ASN information using BGPView API
+func GetASNInfo(ctx context.Context, asn string) (*BGPViewResponse, error) {
+	client := NewBGPViewClient()
+	return client.GetASNInfo(ctx, asn)
+}
+
+// GetASNInfoWithTimeout retrieves comprehensive ASN information using BGPView API with timeout
+func GetASNInfoWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*BGPViewResponse, error) {
+	client := NewBGPViewClient()
+	return client.GetASNInfoWithTimeout(ctx, asn, timeout)
+}
+
+// GetASNInfo retrieves basic ASN information using BGPView API
+// This provides an alternative to Cymru DNS for ASN description lookup
+func (c *BGPViewClient) GetASNInfo(ctx context.Context, asn string) (*BGPViewResponse, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Normalize ASN format for API call
+	normalizedASN := normalizeASNForAPI(asn)
+
+	url := fmt.Sprintf("%s/asn/%s", c.baseURL, normalizedASN)
+	log.Debug("Making BGPView ASN info request", svc1log.SafeParam("url", url))
+
+	// Use the retry logic
+	resp, err := c.makeRequestWithRetry(ctx, url, 0) // No timeout for this method
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("received nil response from BGPView API")
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warn("Failed to close response body", svc1log.SafeParam("error", closeErr.Error()))
+		}
+	}()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("BGPView API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Read and parse response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var bgpResponse BGPViewResponse
+	if err := json.Unmarshal(body, &bgpResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	if bgpResponse.Status != "ok" {
+		return nil, fmt.Errorf("BGPView API error: %s", bgpResponse.StatusMessage)
+	}
+
+	return &bgpResponse, nil
+}
+
+// GetASNPrefixesWithTimeout retrieves all BGP prefixes for a given ASN with timeout
+func (c *BGPViewClient) GetASNPrefixesWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*BGPViewResponse, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Normalize ASN format for API call
+	normalizedASN := normalizeASNForAPI(asn)
+
+	url := fmt.Sprintf("%s/asn/%s/prefixes", c.baseURL, normalizedASN)
+	log.Debug("Making BGPView API request with timeout",
+		svc1log.SafeParam("url", url),
+		svc1log.SafeParam("asn", normalizedASN),
+		svc1log.SafeParam("timeout", timeout.String()))
+
+	// Use the retry logic with timeout
+	resp, err := c.makeRequestWithRetry(ctx, url, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("received nil response from BGPView API")
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warn("Failed to close response body", svc1log.SafeParam("error", closeErr.Error()))
+		}
+	}()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("BGPView API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	// Parse JSON response
+	var bgpResponse BGPViewResponse
+	if err := json.Unmarshal(body, &bgpResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	// Check API status
+	if bgpResponse.Status != "ok" {
+		return nil, fmt.Errorf("BGPView API error: %s", bgpResponse.StatusMessage)
+	}
+
+	log.Debug("BGPView API response received",
+		svc1log.SafeParam("ipv4_prefixes", len(bgpResponse.Data.IPv4Prefixes)),
+		svc1log.SafeParam("ipv6_prefixes", len(bgpResponse.Data.IPv6Prefixes)),
+		svc1log.SafeParam("execution_time", bgpResponse.Meta.ExecutionTime))
+
+	return &bgpResponse, nil
+}
+
+// GetASNInfoWithTimeout retrieves basic ASN information using BGPView API with timeout
+func (c *BGPViewClient) GetASNInfoWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*BGPViewResponse, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Normalize ASN format for API call
+	normalizedASN := normalizeASNForAPI(asn)
+
+	url := fmt.Sprintf("%s/asn/%s", c.baseURL, normalizedASN)
+	log.Debug("Making BGPView ASN info request with timeout",
+		svc1log.SafeParam("url", url),
+		svc1log.SafeParam("timeout", timeout.String()))
+
+	// Use the retry logic with timeout
+	resp, err := c.makeRequestWithRetry(ctx, url, timeout)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("received nil response from BGPView API")
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warn("Failed to close response body", svc1log.SafeParam("error", closeErr.Error()))
+		}
+	}()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("BGPView API returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// Read and parse response
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var bgpResponse BGPViewResponse
+	if err := json.Unmarshal(body, &bgpResponse); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+
+	if bgpResponse.Status != "ok" {
+		return nil, fmt.Errorf("BGPView API error: %s", bgpResponse.StatusMessage)
+	}
+
+	return &bgpResponse, nil
+}

--- a/utils/bgpview.go
+++ b/utils/bgpview.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	utilsfern "github.com/Method-Security/osintscan/generated/go/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
@@ -20,65 +21,6 @@ type BGPViewClient struct {
 	baseURL    string
 	httpClient *http.Client
 	userAgent  string
-}
-
-// BGPViewResponse represents the top-level response from BGPView API
-type BGPViewResponse struct {
-	Status        string       `json:"status"`
-	StatusMessage string       `json:"status_message"`
-	Data          *BGPViewData `json:"data"`
-	Meta          *BGPViewMeta `json:"@meta"`
-}
-
-// BGPViewData represents the data section of BGPView response
-type BGPViewData struct {
-	IPv4Prefixes []BGPViewPrefix `json:"ipv4_prefixes"`
-	IPv6Prefixes []BGPViewPrefix `json:"ipv6_prefixes"`
-	// ASN Info fields
-	ASN           int                   `json:"asn"`
-	Name          string                `json:"name"`
-	Description   string                `json:"description_short"`
-	CountryCode   string                `json:"country_code"`
-	Website       string                `json:"website"`
-	EmailContacts []string              `json:"email_contacts"`
-	AbuseContacts []string              `json:"abuse_contacts"`
-	RIRAllocation *BGPViewRIRAllocation `json:"rir_allocation"`
-}
-
-// BGPViewPrefix represents a BGP prefix from BGPView API
-type BGPViewPrefix struct {
-	Prefix      string               `json:"prefix"`
-	IP          string               `json:"ip"`
-	CIDR        int                  `json:"cidr"`
-	ROAStatus   string               `json:"roa_status"`
-	Name        string               `json:"name"`
-	Description string               `json:"description"`
-	CountryCode string               `json:"country_code"`
-	Parent      *BGPViewPrefixParent `json:"parent"`
-}
-
-// BGPViewPrefixParent represents parent prefix information
-type BGPViewPrefixParent struct {
-	Prefix           string `json:"prefix"`
-	IP               string `json:"ip"`
-	CIDR             int    `json:"cidr"`
-	RIRName          string `json:"rir_name"`
-	AllocationStatus string `json:"allocation_status"`
-}
-
-// BGPViewRIRAllocation represents RIR allocation information
-type BGPViewRIRAllocation struct {
-	RIRName          string `json:"rir_name"`
-	CountryCode      string `json:"country_code"`
-	DateAllocated    string `json:"date_allocated"`
-	AllocationStatus string `json:"allocation_status"`
-}
-
-// BGPViewMeta represents metadata from BGPView API
-type BGPViewMeta struct {
-	TimeZone      string `json:"time_zone"`
-	APIVersion    int    `json:"api_version"`
-	ExecutionTime string `json:"execution_time"`
 }
 
 // NewBGPViewClient creates a new BGPView API client
@@ -152,8 +94,8 @@ func (c *BGPViewClient) makeRequestWithRetry(ctx context.Context, url string, ti
 				return nil, fmt.Errorf("timeout exceeded after %v while retrying 429 responses", timeout)
 			}
 
-			// Calculate random backoff between 10-60 seconds
-			backoff := time.Duration(10+rand.Intn(51)) * time.Second
+			// Calculate random backoff between 10-30 seconds
+			backoff := time.Duration(10+rand.Intn(21)) * time.Second
 
 			log.Warn("Received 429 from BGPView API, retrying with backoff",
 				svc1log.SafeParam("attempt", attempt),
@@ -175,7 +117,7 @@ func (c *BGPViewClient) makeRequestWithRetry(ctx context.Context, url string, ti
 }
 
 // GetASNPrefixes retrieves all BGP prefixes for a given ASN
-func (c *BGPViewClient) GetASNPrefixes(ctx context.Context, asn string) (*BGPViewResponse, error) {
+func (c *BGPViewClient) GetASNPrefixes(ctx context.Context, asn string) (*utilsfern.BgpViewResponse, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Normalize ASN format for API call
@@ -211,7 +153,7 @@ func (c *BGPViewClient) GetASNPrefixes(ctx context.Context, asn string) (*BGPVie
 	}
 
 	// Parse JSON response
-	var bgpResponse BGPViewResponse
+	var bgpResponse utilsfern.BgpViewResponse
 	if err := json.Unmarshal(body, &bgpResponse); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
 	}
@@ -222,9 +164,24 @@ func (c *BGPViewClient) GetASNPrefixes(ctx context.Context, asn string) (*BGPVie
 	}
 
 	log.Debug("BGPView API response received",
-		svc1log.SafeParam("ipv4_prefixes", len(bgpResponse.Data.IPv4Prefixes)),
-		svc1log.SafeParam("ipv6_prefixes", len(bgpResponse.Data.IPv6Prefixes)),
-		svc1log.SafeParam("execution_time", bgpResponse.Meta.ExecutionTime))
+		svc1log.SafeParam("ipv4_prefixes", func() int {
+			if bgpResponse.Data != nil {
+				return len(bgpResponse.Data.Ipv4Prefixes)
+			}
+			return 0
+		}()),
+		svc1log.SafeParam("ipv6_prefixes", func() int {
+			if bgpResponse.Data != nil {
+				return len(bgpResponse.Data.Ipv6Prefixes)
+			}
+			return 0
+		}()),
+		svc1log.SafeParam("execution_time", func() string {
+			if bgpResponse.Meta != nil {
+				return bgpResponse.Meta.ExecutionTime
+			}
+			return ""
+		}()))
 
 	return &bgpResponse, nil
 }
@@ -251,14 +208,14 @@ func GetASNCIDRs(ctx context.Context, asn string) ([]string, error) {
 	var cidrs []string
 
 	// Add IPv4 prefixes
-	for _, prefix := range response.Data.IPv4Prefixes {
+	for _, prefix := range response.Data.Ipv4Prefixes {
 		if prefix.Prefix != "" {
 			cidrs = append(cidrs, prefix.Prefix)
 		}
 	}
 
 	// Add IPv6 prefixes
-	for _, prefix := range response.Data.IPv6Prefixes {
+	for _, prefix := range response.Data.Ipv6Prefixes {
 		if prefix.Prefix != "" {
 			cidrs = append(cidrs, prefix.Prefix)
 		}
@@ -267,8 +224,8 @@ func GetASNCIDRs(ctx context.Context, asn string) ([]string, error) {
 	log.Info("Retrieved ASN CIDRs from BGPView",
 		svc1log.SafeParam("asn", asn),
 		svc1log.SafeParam("total_cidrs", len(cidrs)),
-		svc1log.SafeParam("ipv4_cidrs", len(response.Data.IPv4Prefixes)),
-		svc1log.SafeParam("ipv6_cidrs", len(response.Data.IPv6Prefixes)))
+		svc1log.SafeParam("ipv4_cidrs", len(response.Data.Ipv4Prefixes)),
+		svc1log.SafeParam("ipv6_cidrs", len(response.Data.Ipv6Prefixes)))
 
 	return cidrs, nil
 }
@@ -296,14 +253,14 @@ func GetASNCIDRsWithTimeout(ctx context.Context, asn string, timeout time.Durati
 	var cidrs []string
 
 	// Add IPv4 prefixes
-	for _, prefix := range response.Data.IPv4Prefixes {
+	for _, prefix := range response.Data.Ipv4Prefixes {
 		if prefix.Prefix != "" {
 			cidrs = append(cidrs, prefix.Prefix)
 		}
 	}
 
 	// Add IPv6 prefixes
-	for _, prefix := range response.Data.IPv6Prefixes {
+	for _, prefix := range response.Data.Ipv6Prefixes {
 		if prefix.Prefix != "" {
 			cidrs = append(cidrs, prefix.Prefix)
 		}
@@ -312,15 +269,15 @@ func GetASNCIDRsWithTimeout(ctx context.Context, asn string, timeout time.Durati
 	log.Info("Retrieved ASN CIDRs from BGPView",
 		svc1log.SafeParam("asn", asn),
 		svc1log.SafeParam("total_cidrs", len(cidrs)),
-		svc1log.SafeParam("ipv4_cidrs", len(response.Data.IPv4Prefixes)),
-		svc1log.SafeParam("ipv6_cidrs", len(response.Data.IPv6Prefixes)))
+		svc1log.SafeParam("ipv4_cidrs", len(response.Data.Ipv4Prefixes)),
+		svc1log.SafeParam("ipv6_cidrs", len(response.Data.Ipv6Prefixes)))
 
 	return cidrs, nil
 }
 
 // GetASNCIDRsDetailed retrieves detailed CIDR information for a given ASN
 // Returns the full BGPView response with additional metadata
-func GetASNCIDRsDetailed(ctx context.Context, asn string) (*BGPViewResponse, error) {
+func GetASNCIDRsDetailed(ctx context.Context, asn string) (*utilsfern.BgpViewResponse, error) {
 	client := NewBGPViewClient()
 	return client.GetASNPrefixes(ctx, asn)
 }
@@ -340,7 +297,7 @@ func normalizeASNForAPI(asn string) string {
 }
 
 // ExtractCIDRsByCountry filters CIDRs by country code from BGPView response
-func ExtractCIDRsByCountry(response *BGPViewResponse, countryCode string) []string {
+func ExtractCIDRsByCountry(response *utilsfern.BgpViewResponse, countryCode string) []string {
 	if response == nil || response.Data == nil {
 		return nil
 	}
@@ -349,14 +306,14 @@ func ExtractCIDRsByCountry(response *BGPViewResponse, countryCode string) []stri
 	countryCode = strings.ToUpper(strings.TrimSpace(countryCode))
 
 	// Filter IPv4 prefixes by country
-	for _, prefix := range response.Data.IPv4Prefixes {
+	for _, prefix := range response.Data.Ipv4Prefixes {
 		if strings.ToUpper(prefix.CountryCode) == countryCode {
 			cidrs = append(cidrs, prefix.Prefix)
 		}
 	}
 
 	// Filter IPv6 prefixes by country
-	for _, prefix := range response.Data.IPv6Prefixes {
+	for _, prefix := range response.Data.Ipv6Prefixes {
 		if strings.ToUpper(prefix.CountryCode) == countryCode {
 			cidrs = append(cidrs, prefix.Prefix)
 		}
@@ -366,20 +323,20 @@ func ExtractCIDRsByCountry(response *BGPViewResponse, countryCode string) []stri
 }
 
 // GetASNInfo retrieves comprehensive ASN information using BGPView API
-func GetASNInfo(ctx context.Context, asn string) (*BGPViewResponse, error) {
+func GetASNInfo(ctx context.Context, asn string) (*utilsfern.BgpViewResponse, error) {
 	client := NewBGPViewClient()
 	return client.GetASNInfo(ctx, asn)
 }
 
 // GetASNInfoWithTimeout retrieves comprehensive ASN information using BGPView API with timeout
-func GetASNInfoWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*BGPViewResponse, error) {
+func GetASNInfoWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*utilsfern.BgpViewResponse, error) {
 	client := NewBGPViewClient()
 	return client.GetASNInfoWithTimeout(ctx, asn, timeout)
 }
 
 // GetASNInfo retrieves basic ASN information using BGPView API
 // This provides an alternative to Cymru DNS for ASN description lookup
-func (c *BGPViewClient) GetASNInfo(ctx context.Context, asn string) (*BGPViewResponse, error) {
+func (c *BGPViewClient) GetASNInfo(ctx context.Context, asn string) (*utilsfern.BgpViewResponse, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Normalize ASN format for API call
@@ -414,7 +371,7 @@ func (c *BGPViewClient) GetASNInfo(ctx context.Context, asn string) (*BGPViewRes
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	var bgpResponse BGPViewResponse
+	var bgpResponse utilsfern.BgpViewResponse
 	if err := json.Unmarshal(body, &bgpResponse); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
 	}
@@ -427,7 +384,7 @@ func (c *BGPViewClient) GetASNInfo(ctx context.Context, asn string) (*BGPViewRes
 }
 
 // GetASNPrefixesWithTimeout retrieves all BGP prefixes for a given ASN with timeout
-func (c *BGPViewClient) GetASNPrefixesWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*BGPViewResponse, error) {
+func (c *BGPViewClient) GetASNPrefixesWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*utilsfern.BgpViewResponse, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Normalize ASN format for API call
@@ -466,7 +423,7 @@ func (c *BGPViewClient) GetASNPrefixesWithTimeout(ctx context.Context, asn strin
 	}
 
 	// Parse JSON response
-	var bgpResponse BGPViewResponse
+	var bgpResponse utilsfern.BgpViewResponse
 	if err := json.Unmarshal(body, &bgpResponse); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
 	}
@@ -477,15 +434,30 @@ func (c *BGPViewClient) GetASNPrefixesWithTimeout(ctx context.Context, asn strin
 	}
 
 	log.Debug("BGPView API response received",
-		svc1log.SafeParam("ipv4_prefixes", len(bgpResponse.Data.IPv4Prefixes)),
-		svc1log.SafeParam("ipv6_prefixes", len(bgpResponse.Data.IPv6Prefixes)),
-		svc1log.SafeParam("execution_time", bgpResponse.Meta.ExecutionTime))
+		svc1log.SafeParam("ipv4_prefixes", func() int {
+			if bgpResponse.Data != nil {
+				return len(bgpResponse.Data.Ipv4Prefixes)
+			}
+			return 0
+		}()),
+		svc1log.SafeParam("ipv6_prefixes", func() int {
+			if bgpResponse.Data != nil {
+				return len(bgpResponse.Data.Ipv6Prefixes)
+			}
+			return 0
+		}()),
+		svc1log.SafeParam("execution_time", func() string {
+			if bgpResponse.Meta != nil {
+				return bgpResponse.Meta.ExecutionTime
+			}
+			return ""
+		}()))
 
 	return &bgpResponse, nil
 }
 
 // GetASNInfoWithTimeout retrieves basic ASN information using BGPView API with timeout
-func (c *BGPViewClient) GetASNInfoWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*BGPViewResponse, error) {
+func (c *BGPViewClient) GetASNInfoWithTimeout(ctx context.Context, asn string, timeout time.Duration) (*utilsfern.BgpViewResponse, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Normalize ASN format for API call
@@ -522,7 +494,7 @@ func (c *BGPViewClient) GetASNInfoWithTimeout(ctx context.Context, asn string, t
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	var bgpResponse BGPViewResponse
+	var bgpResponse utilsfern.BgpViewResponse
 	if err := json.Unmarshal(body, &bgpResponse); err != nil {
 		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
 	}

--- a/utils/cymruasn.go
+++ b/utils/cymruasn.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/miekg/dns"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
@@ -44,14 +45,11 @@ func IPASNLookupDetailed(ctx context.Context, ip string) (*CymruASNResult, error
 	}
 
 	// Determine if IPv4 or IPv6 and construct the query domain
-	var queryDomain string
-	if parsedIP.To4() != nil {
-		// IPv4 - reverse the octets
-		queryDomain = reverseIPv4(ip) + ".origin.asn.cymru.com"
-	} else {
-		// IPv6 - reverse the nibbles
-		queryDomain = reverseIPv6(ip) + ".origin6.asn.cymru.com"
+	reversed, err := reverseIPBare(ip)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reverse IP: %w", err)
 	}
+	queryDomain := reversed + ".origin.asn.cymru.com"
 
 	log.Debug("Performing Cymru ASN lookup", svc1log.SafeParam("ip", ip), svc1log.SafeParam("query_domain", queryDomain))
 
@@ -91,43 +89,24 @@ func IPASNLookupDetailed(ctx context.Context, ip string) (*CymruASNResult, error
 	return result, nil
 }
 
-// reverseIPv4 reverses the octets of an IPv4 address
-// Example: 216.90.108.31 becomes 31.108.90.216
-func reverseIPv4(ip string) string {
-	parts := strings.Split(ip, ".")
-	if len(parts) != 4 {
-		return ip // Return original if not valid IPv4 format
+// ReverseIPBare returns the reversed form used in PTR construction,
+// but without the zone suffixes (".in-addr.arpa" / ".ip6.arpa") and trailing dot.
+// Examples:
+//
+//	"216.90.108.31"        -> "31.108.90.216"
+//	"2001:db8::1"          -> "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2"
+func reverseIPBare(ip string) (string, error) {
+	ptr, err := dns.ReverseAddr(ip)
+	if err != nil {
+		return "", err
 	}
 
-	// Reverse the order
-	return fmt.Sprintf("%s.%s.%s.%s", parts[3], parts[2], parts[1], parts[0])
-}
-
-// reverseIPv6 reverses the nibbles of an IPv6 address for PTR-style DNS queries
-// Example: 2001:db8::1 becomes 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2
-func reverseIPv6(ip string) string {
-	parsedIP := net.ParseIP(ip)
-	if parsedIP == nil {
-		return ip
-	}
-
-	// Get the 16-byte representation of IPv6
-	ipv6Bytes := parsedIP.To16()
-	if ipv6Bytes == nil {
-		return ip
-	}
-
-	// Convert each byte to two hex digits and reverse the nibbles
-	var nibbles []string
-	for i := len(ipv6Bytes) - 1; i >= 0; i-- {
-		b := ipv6Bytes[i]
-		// Add the lower nibble first (reverse nibble order within byte)
-		nibbles = append(nibbles, fmt.Sprintf("%x", b&0x0f))
-		// Add the upper nibble
-		nibbles = append(nibbles, fmt.Sprintf("%x", (b&0xf0)>>4))
-	}
-
-	return strings.Join(nibbles, ".")
+	// Normalize and strip the trailing dot and known reverse zones.
+	s := strings.ToLower(ptr)
+	s = strings.TrimSuffix(s, ".")
+	s = strings.TrimSuffix(s, ".in-addr.arpa")
+	s = strings.TrimSuffix(s, ".ip6.arpa")
+	return s, nil
 }
 
 // parseCymruTXTRecord parses a Cymru TXT record response
@@ -183,8 +162,14 @@ func parseCymruTXTRecord(record string) (*CymruASNResult, error) {
 
 // GetASNDescription looks up the description for a given ASN using Cymru's asn.cymru.com zone
 // Example query: dig +short AS23028.asn.cymru.com TXT
-func GetASNDescription(ctx context.Context, asn string) (string, error) {
+func GetASNDescription(ctx context.Context, asn string, timeout ...time.Duration) (string, error) {
 	log := svc1log.FromContext(ctx)
+
+	// Set default timeout to 5 if not provided
+	actualTimeout := 5 * time.Second
+	if len(timeout) > 0 && timeout[0] > 0 {
+		actualTimeout = timeout[0]
+	}
 
 	// Normalize ASN format - ensure it starts with AS and is numeric
 	normalizedASN, err := normalizeASN(asn)
@@ -200,7 +185,7 @@ func GetASNDescription(ctx context.Context, asn string) (string, error) {
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 			d := net.Dialer{
-				Timeout: 5 * time.Second,
+				Timeout: actualTimeout * time.Second,
 			}
 			return d.DialContext(ctx, network, address)
 		},

--- a/utils/cymruasn.go
+++ b/utils/cymruasn.go
@@ -8,20 +8,12 @@ import (
 	"strings"
 	"time"
 
+	utilsfern "github.com/Method-Security/osintscan/generated/go/utils"
 	"github.com/miekg/dns"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // Cymru offers quality WHOIS and DNS based ASN services particularly for IP to ASN lookups
-
-// CymruASNResult represents the parsed result from a Cymru ASN lookup
-type CymruASNResult struct {
-	ASN         string
-	BGPPrefix   string
-	CountryCode string
-	Registry    string
-	AllocDate   string
-}
 
 // IPASNLookup performs an ASN lookup using the Cymru DNS service
 // Returns ASN information for the given IP address using raw DNS queries
@@ -30,12 +22,12 @@ func IPASNLookup(ctx context.Context, ip string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return result.ASN, nil
+	return result.Asn, nil
 }
 
 // IPASNLookupDetailed performs an ASN lookup using the Cymru DNS service
 // Returns detailed ASN information for the given IP address using raw DNS queries
-func IPASNLookupDetailed(ctx context.Context, ip string) (*CymruASNResult, error) {
+func IPASNLookupDetailed(ctx context.Context, ip string) (*utilsfern.CymruAsnResult, error) {
 	log := svc1log.FromContext(ctx)
 
 	// Validate IP address
@@ -112,7 +104,7 @@ func reverseIPBare(ip string) (string, error) {
 // parseCymruTXTRecord parses a Cymru TXT record response
 // Format: "ASN | BGP Prefix | Country Code | Registry | Allocation Date"
 // Example: "23028 | 216.90.108.0/24 | US | arin | 1998-09-25"
-func parseCymruTXTRecord(record string) (*CymruASNResult, error) {
+func parseCymruTXTRecord(record string) (*utilsfern.CymruAsnResult, error) {
 	// Remove surrounding quotes if present
 	record = strings.Trim(record, "\"")
 
@@ -139,13 +131,13 @@ func parseCymruTXTRecord(record string) (*CymruASNResult, error) {
 		asn = "AS" + asn
 	}
 
-	result := &CymruASNResult{
-		ASN: asn,
+	result := &utilsfern.CymruAsnResult{
+		Asn: asn,
 	}
 
 	// Parse optional fields
 	if len(parts) >= 2 {
-		result.BGPPrefix = strings.TrimSpace(parts[1])
+		result.BgpPrefix = strings.TrimSpace(parts[1])
 	}
 	if len(parts) >= 3 {
 		result.CountryCode = strings.TrimSpace(parts[2])

--- a/utils/cymruasn.go
+++ b/utils/cymruasn.go
@@ -1,0 +1,258 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// Cymru offers quality WHOIS and DNS based ASN services particularly for IP to ASN lookups
+
+// CymruASNResult represents the parsed result from a Cymru ASN lookup
+type CymruASNResult struct {
+	ASN         string
+	BGPPrefix   string
+	CountryCode string
+	Registry    string
+	AllocDate   string
+}
+
+// IPASNLookup performs an ASN lookup using the Cymru DNS service
+// Returns ASN information for the given IP address using raw DNS queries
+func IPASNLookup(ctx context.Context, ip string) (string, error) {
+	result, err := IPASNLookupDetailed(ctx, ip)
+	if err != nil {
+		return "", err
+	}
+	return result.ASN, nil
+}
+
+// IPASNLookupDetailed performs an ASN lookup using the Cymru DNS service
+// Returns detailed ASN information for the given IP address using raw DNS queries
+func IPASNLookupDetailed(ctx context.Context, ip string) (*CymruASNResult, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Validate IP address
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return nil, fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	// Determine if IPv4 or IPv6 and construct the query domain
+	var queryDomain string
+	if parsedIP.To4() != nil {
+		// IPv4 - reverse the octets
+		queryDomain = reverseIPv4(ip) + ".origin.asn.cymru.com"
+	} else {
+		// IPv6 - reverse the nibbles
+		queryDomain = reverseIPv6(ip) + ".origin6.asn.cymru.com"
+	}
+
+	log.Debug("Performing Cymru ASN lookup", svc1log.SafeParam("ip", ip), svc1log.SafeParam("query_domain", queryDomain))
+
+	// Create a resolver with reasonable timeout
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 5 * time.Second,
+			}
+			return d.DialContext(ctx, network, address)
+		},
+	}
+
+	// Perform TXT record lookup
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	records, err := resolver.LookupTXT(ctx, queryDomain)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup TXT record for %s: %w", queryDomain, err)
+	}
+
+	if len(records) == 0 {
+		return nil, fmt.Errorf("no TXT records found for %s", queryDomain)
+	}
+
+	// Parse the first TXT record (Cymru typically returns one record)
+	txtRecord := records[0]
+	log.Debug("Cymru TXT record", svc1log.SafeParam("record", txtRecord))
+
+	result, err := parseCymruTXTRecord(txtRecord)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse Cymru TXT record '%s': %w", txtRecord, err)
+	}
+
+	return result, nil
+}
+
+// reverseIPv4 reverses the octets of an IPv4 address
+// Example: 216.90.108.31 becomes 31.108.90.216
+func reverseIPv4(ip string) string {
+	parts := strings.Split(ip, ".")
+	if len(parts) != 4 {
+		return ip // Return original if not valid IPv4 format
+	}
+
+	// Reverse the order
+	return fmt.Sprintf("%s.%s.%s.%s", parts[3], parts[2], parts[1], parts[0])
+}
+
+// reverseIPv6 reverses the nibbles of an IPv6 address for PTR-style DNS queries
+// Example: 2001:db8::1 becomes 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2
+func reverseIPv6(ip string) string {
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		return ip
+	}
+
+	// Get the 16-byte representation of IPv6
+	ipv6Bytes := parsedIP.To16()
+	if ipv6Bytes == nil {
+		return ip
+	}
+
+	// Convert each byte to two hex digits and reverse the nibbles
+	var nibbles []string
+	for i := len(ipv6Bytes) - 1; i >= 0; i-- {
+		b := ipv6Bytes[i]
+		// Add the lower nibble first (reverse nibble order within byte)
+		nibbles = append(nibbles, fmt.Sprintf("%x", b&0x0f))
+		// Add the upper nibble
+		nibbles = append(nibbles, fmt.Sprintf("%x", (b&0xf0)>>4))
+	}
+
+	return strings.Join(nibbles, ".")
+}
+
+// parseCymruTXTRecord parses a Cymru TXT record response
+// Format: "ASN | BGP Prefix | Country Code | Registry | Allocation Date"
+// Example: "23028 | 216.90.108.0/24 | US | arin | 1998-09-25"
+func parseCymruTXTRecord(record string) (*CymruASNResult, error) {
+	// Remove surrounding quotes if present
+	record = strings.Trim(record, "\"")
+
+	// Split by pipe character
+	parts := strings.Split(record, "|")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid Cymru record format: expected at least 2 pipe-separated fields, got %d", len(parts))
+	}
+
+	// Parse ASN (first field)
+	asnStr := strings.TrimSpace(parts[0])
+	if asnStr == "" {
+		return nil, fmt.Errorf("empty ASN field in Cymru record")
+	}
+
+	// Validate ASN is numeric and convert to standard ASN format
+	if _, err := strconv.Atoi(asnStr); err != nil {
+		return nil, fmt.Errorf("invalid ASN format '%s': %w", asnStr, err)
+	}
+
+	// Ensure ASN has AS prefix
+	asn := asnStr
+	if !strings.HasPrefix(strings.ToUpper(asn), "AS") {
+		asn = "AS" + asn
+	}
+
+	result := &CymruASNResult{
+		ASN: asn,
+	}
+
+	// Parse optional fields
+	if len(parts) >= 2 {
+		result.BGPPrefix = strings.TrimSpace(parts[1])
+	}
+	if len(parts) >= 3 {
+		result.CountryCode = strings.TrimSpace(parts[2])
+	}
+	if len(parts) >= 4 {
+		result.Registry = strings.TrimSpace(parts[3])
+	}
+	if len(parts) >= 5 {
+		result.AllocDate = strings.TrimSpace(parts[4])
+	}
+
+	return result, nil
+}
+
+// GetASNDescription looks up the description for a given ASN using Cymru's asn.cymru.com zone
+// Example query: dig +short AS23028.asn.cymru.com TXT
+func GetASNDescription(ctx context.Context, asn string) (string, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Normalize ASN format - ensure it starts with AS and is numeric
+	normalizedASN, err := normalizeASN(asn)
+	if err != nil {
+		return "", fmt.Errorf("invalid ASN format '%s': %w", asn, err)
+	}
+
+	queryDomain := normalizedASN + ".asn.cymru.com"
+	log.Debug("Looking up ASN description", svc1log.SafeParam("asn", normalizedASN), svc1log.SafeParam("query_domain", queryDomain))
+
+	// Create a resolver with reasonable timeout
+	resolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 5 * time.Second,
+			}
+			return d.DialContext(ctx, network, address)
+		},
+	}
+
+	// Perform TXT record lookup
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	records, err := resolver.LookupTXT(ctx, queryDomain)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup TXT record for %s: %w", queryDomain, err)
+	}
+
+	if len(records) == 0 {
+		return "", fmt.Errorf("no TXT records found for %s", queryDomain)
+	}
+
+	// Parse the description from the TXT record
+	description := strings.Trim(records[0], "\"")
+	// Cymru ASN description format is typically: "ASN | Country | Registry | Description"
+	parts := strings.Split(description, "|")
+	if len(parts) >= 4 {
+		return strings.TrimSpace(parts[3]), nil
+	}
+
+	// If format is different, return the whole record
+	return description, nil
+}
+
+// normalizeASN ensures ASN is in the correct format for Cymru queries
+func normalizeASN(asn string) (string, error) {
+	// Remove AS prefix and whitespace
+	asnNum := strings.TrimSpace(strings.ToUpper(asn))
+	asnNum = strings.TrimPrefix(asnNum, "AS")
+
+	// Validate it's numeric
+	if _, err := strconv.Atoi(asnNum); err != nil {
+		return "", fmt.Errorf("ASN must be numeric, got '%s'", asnNum)
+	}
+
+	return "AS" + asnNum, nil
+}
+
+// IPASNLookupWithFallback tries Cymru DNS first, then falls back to whois if needed
+func IPASNLookupWithFallback(ctx context.Context, ip string) (string, error) {
+	// Try Cymru first
+	asn, err := IPASNLookup(ctx, ip)
+	if err == nil && asn != "" {
+		return asn, nil
+	}
+
+	// Fall back to whois
+	return WhoisASNWithContext(ctx, ip)
+}

--- a/utils/whois.go
+++ b/utils/whois.go
@@ -1,0 +1,302 @@
+package utils
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math/rand"
+	"net"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Whois is used for getting information on IPs, Domains, and ASNs
+
+// WhoisClient represents a whois client
+type WhoisClient struct {
+	servers []string
+	timeout time.Duration
+}
+
+// Common WHOIS servers for different TLDs and IP ranges
+var defaultWhoisServers = []string{
+	"whois.iana.org",
+	"whois.arin.net",
+	"whois.ripe.net",
+	"whois.apnic.net",
+	"whois.lacnic.net",
+	"whois.afrinic.net",
+	"whois.verisign-grs.com",
+	"whois.crsnic.net",
+	"whois.nic.com",
+	"whois.nic.org",
+	"whois.nic.net",
+	"whois.nic.edu",
+	"whois.nic.gov",
+	"whois.nic.mil",
+	"whois.nic.int",
+	"whois.radb.net",
+	"whois.cymru.com",
+}
+
+// NewWhoisClient creates a new whois client
+func NewWhoisClient() *WhoisClient {
+	return &WhoisClient{
+		servers: defaultWhoisServers,
+		timeout: 10 * time.Second,
+	}
+}
+
+// SetServers sets the whois servers to use
+func (c *WhoisClient) SetServers(servers []string) *WhoisClient {
+	c.servers = servers
+	return c
+}
+
+// SetTimeout sets the timeout for whois queries
+func (c *WhoisClient) SetTimeout(timeout time.Duration) *WhoisClient {
+	c.timeout = timeout
+	return c
+}
+
+// Whois performs a whois lookup on the given domain/IP
+func (c *WhoisClient) Whois(query string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	return c.WhoisWithContext(ctx, query)
+}
+
+// WhoisWithServer performs a whois lookup on the given domain/IP with a specified server
+func (c *WhoisClient) WhoisWithServer(query string, server string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	return c.WhoisWithContextAndServer(ctx, query, server)
+}
+
+// WhoisWithServerVerbose performs a whois lookup on the given domain/IP with a specified server and verbose output
+func (c *WhoisClient) WhoisWithServerVerbose(query string, server string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+	return c.WhoisWithContextAndServerVerbose(ctx, query, server)
+}
+
+// WhoisWithContext performs a whois lookup with a custom context
+func (c *WhoisClient) WhoisWithContext(ctx context.Context, query string) (string, error) {
+	// Create a new context with timeout if not already set
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+
+	// Determine the appropriate WHOIS server for the query
+	server, err := c.selectWhoisServer(query)
+	if err != nil {
+		return "", fmt.Errorf("failed to select WHOIS server: %w", err)
+	}
+
+	// Perform the WHOIS query
+	return c.rawQuery(ctx, query, server)
+}
+
+// WhoisWithContextAndServer performs a whois lookup with a custom context and specified server
+func (c *WhoisClient) WhoisWithContextAndServer(ctx context.Context, query string, server string) (string, error) {
+	// Create a new context with timeout if not already set
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+
+	// Validate server parameter
+	if server == "" {
+		return "", fmt.Errorf("WHOIS server cannot be empty")
+	}
+
+	// Perform the WHOIS query with the specified server
+	return c.rawQuery(ctx, query, server)
+}
+
+// WhoisWithContextAndServerVerbose performs a whois lookup with a custom context, specified server, and verbose output
+func (c *WhoisClient) WhoisWithContextAndServerVerbose(ctx context.Context, query string, server string) (string, error) {
+	// Create a new context with timeout if not already set
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+
+	// Validate server parameter
+	if server == "" {
+		return "", fmt.Errorf("WHOIS server cannot be empty")
+	}
+
+	// Perform the WHOIS query with the specified server and verbose flag
+	return c.rawQueryWithOptions(ctx, query, server, true)
+}
+
+// selectWhoisServer determines the appropriate WHOIS server for the query
+func (c *WhoisClient) selectWhoisServer(query string) (string, error) {
+	// For IP addresses, try to determine the appropriate RIR
+	if net.ParseIP(query) != nil {
+		return c.selectRIRServer(query), nil
+	}
+
+	// For domains, we'll use a random server from our list
+	// In a more sophisticated implementation, you could maintain a mapping
+	// of TLDs to their specific WHOIS servers
+	if len(c.servers) == 0 {
+		return "", fmt.Errorf("no WHOIS servers configured")
+	}
+
+	// Randomly select a server
+	rand.Seed(time.Now().UnixNano())
+	return c.servers[rand.Intn(len(c.servers))], nil
+}
+
+// selectRIRServer selects the appropriate Regional Internet Registry server for an IP
+func (c *WhoisClient) selectRIRServer(ip string) string {
+	// Parse the IP to determine the RIR
+	parsedIP := net.ParseIP(ip)
+	if parsedIP == nil {
+		// Fallback to a random server
+		rand.Seed(time.Now().UnixNano())
+		return c.servers[rand.Intn(len(c.servers))]
+	}
+
+	// Simple RIR selection based on IP ranges
+	if parsedIP.To4() != nil {
+		// IPv4
+		firstOctet := parsedIP[0]
+		switch {
+		case firstOctet <= 127:
+			return "whois.arin.net" // North America
+		case firstOctet <= 191:
+			return "whois.ripe.net" // Europe
+		case firstOctet <= 223:
+			return "whois.apnic.net" // Asia Pacific
+		default:
+			return "whois.arin.net" // Default fallback
+		}
+	} else {
+		// IPv6 - simplified selection
+		// In practice, you'd want more sophisticated IPv6 RIR detection
+		return "whois.ripe.net"
+	}
+}
+
+// rawQuery performs a raw TCP WHOIS query
+func (c *WhoisClient) rawQuery(ctx context.Context, query, server string) (string, error) {
+	return c.rawQueryWithOptions(ctx, query, server, false)
+}
+
+// rawQueryWithOptions performs a raw TCP WHOIS query with optional verbose flag
+func (c *WhoisClient) rawQueryWithOptions(ctx context.Context, query, server string, verbose bool) (string, error) {
+	// Connect to the WHOIS server
+	dialer := &net.Dialer{
+		Timeout: c.timeout,
+	}
+
+	conn, err := dialer.DialContext(ctx, "tcp", server+":43")
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to WHOIS server %s: %w", server, err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			// Log the close error but don't return it as it's not critical
+		}
+	}()
+
+	// Set deadline for the connection
+	if deadline, ok := ctx.Deadline(); ok {
+		if err := conn.SetDeadline(deadline); err != nil {
+			return "", fmt.Errorf("failed to set deadline: %w", err)
+		}
+	}
+
+	// Prepare the query with optional verbose flag
+	var queryLine string
+	if verbose {
+		queryLine = " -v " + query + "\r\n"
+	} else {
+		queryLine = query + "\r\n"
+	}
+
+	// Send the query
+	_, err = conn.Write([]byte(queryLine))
+	if err != nil {
+		return "", fmt.Errorf("failed to send query to WHOIS server: %w", err)
+	}
+
+	// Read the response
+	var response strings.Builder
+	scanner := bufio.NewScanner(conn)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		response.WriteString(line)
+		response.WriteString("\n")
+
+		// Check for end of response indicators
+		if strings.Contains(line, "%") && (strings.Contains(line, "end") || strings.Contains(line, "End")) {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to read response from WHOIS server: %w", err)
+	}
+
+	return response.String(), nil
+}
+
+// ExtractASN extracts ASN information from whois output
+func ExtractASN(whoisOutput string) string {
+	// Common patterns for ASN in whois output
+	asnPatterns := []*regexp.Regexp{
+		regexp.MustCompile(`(?i)origin(?:al)?\s*as(?:n)?:?\s*(as\d+)`),
+		regexp.MustCompile(`(?i)autonomous\s+system\s+number:?\s*(as\d+|\d+)`),
+		regexp.MustCompile(`(?i)asn:?\s*(as\d+|\d+)`),
+		regexp.MustCompile(`(?i)as(?:n|num):?\s*(as\d+|\d+)`),
+		regexp.MustCompile(`(?i)origin:?\s*(as\d+)`),
+	}
+
+	lines := strings.Split(whoisOutput, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		for _, pattern := range asnPatterns {
+			matches := pattern.FindStringSubmatch(line)
+			if len(matches) > 1 {
+				asn := strings.ToUpper(matches[1])
+				// Ensure ASN starts with "AS"
+				if !strings.HasPrefix(asn, "AS") {
+					asn = "AS" + asn
+				}
+				return asn
+			}
+		}
+	}
+
+	return ""
+}
+
+// WhoisASN performs a whois lookup and extracts ASN information
+func WhoisASN(query string) (string, error) {
+	client := NewWhoisClient()
+	output, err := client.Whois(query)
+	if err != nil {
+		return "", err
+	}
+	return ExtractASN(output), nil
+}
+
+// WhoisASNWithContext performs a whois lookup with context and extracts ASN information
+func WhoisASNWithContext(ctx context.Context, query string) (string, error) {
+	client := NewWhoisClient()
+	output, err := client.WhoisWithContext(ctx, query)
+	if err != nil {
+		return "", err
+	}
+	return ExtractASN(output), nil
+}


### PR DESCRIPTION
```
go run main.go discover ip domain-asn --help
Perform a reverse DNS lookup and ASN lookup on a single IP, list of IPs, or a CIDR range. Warning: /16 and larger can take upwards of 30 minutes.

Usage:
  osintscan discover ip domain-asn [flags]

Flags:
      --cidr string             The CIDR range to perform reverse DNS and ASN lookup on
      --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53) (default [1.1.1.1:53])
  -h, --help                    help for domainasn
      --ips strings             The IP addresses to perform reverse DNS and ASN lookup on

Global Flags:
  -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
  -f, --output-file string   Path to output file. If blank, will output to STDOUT
  -q, --quiet                Suppress output
  -v, --verbose              Verbose output
  ```

```
go run main.go discover asn --help
Discover information about ASN, including ASN description, CIDRs, country, and other metadata. This relies on BGPView's API and has built in retry and timeout mechanisms.

Usage:
  osintscan discover asn [flags]

Flags:
      --asn string    The ASN number to lookup (e.g., AS23028 or 23028)
  -h, --help          help for asn
      --timeout int   The timeout in seconds for the ASN lookup (default 120)

Global Flags:
  -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
  -f, --output-file string   Path to output file. If blank, will output to STDOUT
  -q, --quiet                Suppress output
  -v, --verbose              Verbose output
```

Examples:
```
go run main.go discover ip domain-asn --ips 203.190.218.40 --output json
go run main.go discover ip domain-asn --cidr 203.190.218.0/24 --output json
go run main.go discover asn --asn AS45218 --output json --verbose
```