### PR TITLE
bugfix: forward-reverse/active subdomain scan OOR when no resolvers are passed

### DIFF
--- a/internal/discover/dns/forwardreverse.go
+++ b/internal/discover/dns/forwardreverse.go
@@ -37,8 +37,12 @@ func getLookups(domain string, dnsResolvers []string) ([]*dnsfern.LookupDetails,
 	log := svc1log.FromContext(ctx)
 	errors := []string{}
 
-	// Pick a random resolver from the list
-	resolver := utils.GetResolver(dnsResolvers[rand.Intn(len(dnsResolvers))], log)
+	resolver := func() *net.Resolver {
+		if len(dnsResolvers) == 0 {
+			return utils.GetResolver("", log)
+		}
+		return utils.GetResolver(dnsResolvers[rand.Intn(len(dnsResolvers))], log)
+	}()
 
 	// Resolve the IP addresses for the given FQDN (forward lookup)
 	ips, err := resolver.LookupHost(ctx, domain)

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -79,10 +79,17 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Minute)
 		defer cancel()
 	}
-	resolvers := []*net.Resolver{}
-	for _, dnsServerAddress := range dnsServerAddresses {
-		resolvers = append(resolvers, utils.GetResolver(dnsServerAddress, log))
-	}
+	resolvers := func() []*net.Resolver {
+		if len(dnsServerAddresses) == 0 {
+			return []*net.Resolver{utils.GetResolver("", log)}
+		}
+
+		result := make([]*net.Resolver, 0, len(dnsServerAddresses))
+		for _, dnsServerAddress := range dnsServerAddresses {
+			result = append(result, utils.GetResolver(dnsServerAddress, log))
+		}
+		return result
+	}()
 
 	// First iteration - test all base subdomains for wildcards
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))


### PR DESCRIPTION
Some discover commands (forward-reverse traversal, active subdomain scanning) can optionally accept a list of DNS resolvers. However, these commands will fail with an out-of-range error if no resolvers are passed.

As other tools in osintscan fall back to the system default DNS resolver, if no resolvers are passed, I call `utils.GetResolver("", ...)` which returns the system default.

```
goroutine 1 [running]:over dns subdomain active --wordlist-file ./osintscan/configs/d --domain exa
github.com/Method-Security/osintscan/internal/discover/dns/subdomain.getSubdomainsActive({0x16e3530, 0xc0008ba480}, {0x7fff42515aa5, 0xb}, {0xc0008c2008, 0x1e8, 0x51b0a5?}, 0xa, 0x2, 0x0, ...)n exam
le.cosin/app/osintscan/internal/discover/dns/subdomain/active.go:89 +0x148f/co --domain example.com
github.com/Method-Security/osintscan/internal/discover/dns/subdomain.GetDomainSubdomainsActive({0x16e3530, 0xc0008ba480}, {{0xc0008be9d0, 0x6}, 0xc000032f30, 0x0, 0x0})ntscan/ --domain example.com
        /app/osintscan/internal/discover/dns/subdomain/active.go:28 +0x145
github.com/Method-Security/osintscan/cmd.(*OsintScan).InitDiscoverCommand.func5(0xc000756f08, {0x1338719?, 0x4?, 0x1338559?})
        /app/osintscan/cmd/discover.go:293 +0x919
github.com/spf13/cobra.(*Command).execute(0xc000756f08, {0xc0007548c0, 0x4, 0x4})
        /app/osintscan/vendor/github.com/spf13/cobra/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003c3208)
        /app/osintscan/vendor/github.com/spf13/cobra/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0xc000615b80?)
        /app/osintscan/vendor/github.com/spf13/cobra/command.go:1041 +0x13
main.main()
        /app/osintscan/main.go:21 +0xa7
```