### PR TITLE
DNS Active: Dont return wildcards

### DIFF
--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -91,8 +91,8 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		return []string{}, err
 	}
 	if wildcardDNS != nil {
-		domain = *wildcardDNS
-		subdomains = append(subdomains, domain)
+		// Wildcard DNS detected - skip brute forcing to avoid false positives
+		log.Info("Wildcard DNS detected, skipping brute force", svc1log.SafeParam("wildcard", *wildcardDNS))
 		return subdomains, nil
 	}
 
@@ -122,8 +122,10 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 				continue
 			}
 			if wildcardDNS != nil {
-				domain = *wildcardDNS
-				subdomains = append(subdomains, domain)
+				// Wildcard DNS detected for this subdomain - skip to avoid false positives
+				log.Info("Wildcard DNS detected for subdomain, skipping",
+					svc1log.SafeParam("subdomain", subdomain),
+					svc1log.SafeParam("wildcard", *wildcardDNS))
 				continue
 			}
 			validSubdomains = append(validSubdomains, subdomain)


### PR DESCRIPTION
### TL;DR

Improved handling of wildcard DNS records during subdomain brute forcing.

### What changed?

- Modified the behavior when wildcard DNS records are detected during subdomain discovery
- Instead of adding the wildcard DNS as a subdomain and returning, now we log the detection and skip the brute force process
- Added more detailed logging when wildcard DNS is detected, including the specific wildcard value
- Enhanced the logging for subdomain-specific wildcard DNS detection with additional context

### How to test?

1. Run subdomain discovery against a domain with wildcard DNS records (e.g., *.example.com)
2. Verify logs show "Wildcard DNS detected, skipping brute force" messages
3. Confirm that wildcard DNS entries are not incorrectly added to the results
4. Test against domains both with and without wildcard DNS to ensure proper behavior in both scenarios

### Why make this change?

Wildcard DNS records can cause false positives during subdomain brute forcing. The previous implementation was incorrectly adding the wildcard DNS record as a valid subdomain and potentially returning inaccurate results. This change improves accuracy by properly skipping brute force attempts when wildcards are detected and provides better visibility through enhanced logging.