### PR TITLE
Correlation CLI (Stop using Active CLI wasnt worth it)

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -141,6 +141,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// subdomain Commands
 	// subdomain active
+	// subdomain correlation
 	// subdomain passive
 	discoverDNSSubdomainCmd := &cobra.Command{
 		Use:   "subdomain",
@@ -149,54 +150,6 @@ func (a *OsintScan) InitDiscoverCommand() {
 	}
 
 	discoverDNSCmd.AddCommand(discoverDNSSubdomainCmd)
-
-	discoverDNSSubdomainPassiveCmd := &cobra.Command{
-		Use:   "passive",
-		Short: "Passively discover subdomains",
-		Long:  `Identify subdomains for the specified domain using only passive data sources (no direct interaction with the target).`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// Parse flags
-			domain, err := cmd.Flags().GetString("domain")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Config Flags
-			requestsPerSecond, err := cmd.Flags().GetInt("requests-per-second")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			threads, err := cmd.Flags().GetInt("threads")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Create config
-			config := getDiscoverDNSPassiveSubdomainConfig(domain, requestsPerSecond, threads)
-
-			// Create report
-			report, err := subdomain.GetDomainSubdomainsPassive(cmd.Context(), config)
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			a.OutputSignal.Content = report
-		},
-	}
-
-	// Target Flags
-	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning")
-
-	// Mark Required Flags
-	_ = discoverDNSSubdomainPassiveCmd.MarkFlagRequired("domain")
-
-	// Add command to 'subdomain' command
-	discoverDNSSubdomainCmd.AddCommand(discoverDNSSubdomainPassiveCmd)
 
 	discoverDNSSubdomainActiveCmd := &cobra.Command{
 		Use:   "active",
@@ -317,6 +270,107 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Add command to 'subdomain' command
 	discoverDNSSubdomainCmd.AddCommand(discoverDNSSubdomainActiveCmd)
+
+	discoverDNSSubdomainCorrelationCmd := &cobra.Command{
+		Use:   "correlation",
+		Short: "Correlate subdomains across multiple domains",
+		Long:  `Correlate subdomains across multiple domains using active data sources (no direct interaction with the target).`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Grab Domains
+			domains, err := cmd.Flags().GetStringSlice("domains")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			// Config Flags
+			threads, err := cmd.Flags().GetInt("threads")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			timeout, err := cmd.Flags().GetInt("timeout")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Create config
+			config := getDiscoverDNSCorrelationSubdomainConfig(domains, threads, timeout, dnsResolvers)
+
+			// Create report
+			report, err := subdomain.GetDomainSubdomainsCorrelation(cmd.Context(), config)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+
+	// Target Flags
+	discoverDNSSubdomainCorrelationCmd.Flags().StringSlice("domains", []string{}, "The domains to test")
+	discoverDNSSubdomainCorrelationCmd.Flags().Int("threads", 10, "Number of parallel threads to use for testing")
+	discoverDNSSubdomainCorrelationCmd.Flags().Int("timeout", 0, "Maximum time (in seconds) to spend on each lookup")
+	discoverDNSSubdomainCorrelationCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
+
+	// Mark Required Flags
+	_ = discoverDNSSubdomainCorrelationCmd.MarkFlagRequired("domains")
+
+	// Add command to 'subdomain' command
+	discoverDNSSubdomainCmd.AddCommand(discoverDNSSubdomainCorrelationCmd)
+
+	discoverDNSSubdomainPassiveCmd := &cobra.Command{
+		Use:   "passive",
+		Short: "Passively discover subdomains",
+		Long:  `Identify subdomains for the specified domain using only passive data sources (no direct interaction with the target).`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Parse flags
+			domain, err := cmd.Flags().GetString("domain")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Config Flags
+			requestsPerSecond, err := cmd.Flags().GetInt("requests-per-second")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			threads, err := cmd.Flags().GetInt("threads")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Create config
+			config := getDiscoverDNSPassiveSubdomainConfig(domain, requestsPerSecond, threads)
+
+			// Create report
+			report, err := subdomain.GetDomainSubdomainsPassive(cmd.Context(), config)
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			a.OutputSignal.Content = report
+		},
+	}
+
+	// Target Flags
+	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning")
+
+	// Mark Required Flags
+	_ = discoverDNSSubdomainPassiveCmd.MarkFlagRequired("domain")
+
+	// Add command to 'subdomain' command
+	discoverDNSSubdomainCmd.AddCommand(discoverDNSSubdomainPassiveCmd)
 
 	discoverShodanCmd := &cobra.Command{
 		Use:   "shodan",
@@ -595,18 +649,6 @@ func getDiscoverDNSForwardReverseConfig(domain string, dnsResolvers []string) dn
 	}
 }
 
-// getDiscoverDNSPassiveSubdomainConfig creates and returns a configuration for passive subdomain discovery
-func getDiscoverDNSPassiveSubdomainConfig(domain string, requestsPerSecond int, threads int) dnsfern.DiscoverDnsSubdomainConfig {
-	return dnsfern.DiscoverDnsSubdomainConfig{
-		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypePassive)),
-		Passive: &dnsfern.DiscoverDnsSubdomainPassiveConfig{
-			Domain:            domain,
-			RequestsPerSecond: requestsPerSecond,
-			Threads:           threads,
-		},
-	}
-}
-
 // getDiscoverDNSActiveSubdomainConfig creates and returns a configuration for active subdomain discovery
 func getDiscoverDNSActiveSubdomainConfig(domain string, subdomains []string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout int, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
 	return dnsfern.DiscoverDnsSubdomainConfig{
@@ -620,6 +662,31 @@ func getDiscoverDNSActiveSubdomainConfig(domain string, subdomains []string, wor
 			MaxDepth:     maxDepth,
 			Timeout:      timeout,
 			DnsResolvers: dnsResolvers,
+		},
+	}
+}
+
+// getDiscoverDNSCorrelationSubdomainConfig creates and returns a configuration for correlation subdomain discovery
+func getDiscoverDNSCorrelationSubdomainConfig(domains []string, threads int, timeout int, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
+	return dnsfern.DiscoverDnsSubdomainConfig{
+		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeCorrelation)),
+		Correlation: &dnsfern.DiscoverDnsSubdomainCorrelationConfig{
+			Domains:      domains,
+			Threads:      threads,
+			Timeout:      timeout,
+			DnsResolvers: dnsResolvers,
+		},
+	}
+}
+
+// getDiscoverDNSPassiveSubdomainConfig creates and returns a configuration for passive subdomain discovery
+func getDiscoverDNSPassiveSubdomainConfig(domain string, requestsPerSecond int, threads int) dnsfern.DiscoverDnsSubdomainConfig {
+	return dnsfern.DiscoverDnsSubdomainConfig{
+		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypePassive)),
+		Passive: &dnsfern.DiscoverDnsSubdomainPassiveConfig{
+			Domain:            domain,
+			RequestsPerSecond: requestsPerSecond,
+			Threads:           threads,
 		},
 	}
 }

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -3,8 +3,8 @@ types:
   DiscoverDnsSubdomainType:
     enum:
       - ACTIVE
+      - CORRELATION
       - PASSIVE
-      - INTELLIGENT
   WordlistSize:
     enum:
       - TINY
@@ -22,6 +22,12 @@ types:
       maxDepth: integer
       timeout: integer
       dnsResolvers: optional<list<string>>
+  DiscoverDnsSubdomainCorrelationConfig:
+    properties:
+      domains: list<string>
+      threads: integer
+      timeout: integer
+      dnsResolvers: optional<list<string>>
   DiscoverDnsSubdomainPassiveConfig:
     properties:
       domain: string
@@ -32,6 +38,7 @@ types:
     discriminant: discoveryType
     union:
       active: DiscoverDnsSubdomainActiveConfig
+      correlation: DiscoverDnsSubdomainCorrelationConfig
       passive: DiscoverDnsSubdomainPassiveConfig
   DiscoverDnsSubdomainResult:
     properties:

--- a/internal/discover/dns/subdomain/correlation.go
+++ b/internal/discover/dns/subdomain/correlation.go
@@ -1,0 +1,172 @@
+package subdomain
+
+import (
+	// Standard
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	// Generated
+	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
+	// Utils
+	"github.com/Method-Security/osintscan/utils"
+	// External
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+)
+
+// GetDomainSubdomainsCorrelation performs FQDN validation and wildcard detection for a list of domains.
+// Returns a report containing validation results and any errors encountered.
+func GetDomainSubdomainsCorrelation(ctx context.Context, config dnsfern.DiscoverDnsSubdomainConfig) (dnsfern.DiscoverDnsSubdomainReport, error) {
+	correlationConfig := config.GetCorrelation()
+	errors := []string{}
+
+	// Run the FQDN correlation checks
+	validatedDomains, err := validateFQDNsWithCorrelation(ctx, correlationConfig.Domains, correlationConfig.Threads, correlationConfig.Timeout, correlationConfig.DnsResolvers)
+	if err != nil {
+		errors = append(errors, err.Error())
+	}
+
+	result := dnsfern.DiscoverDnsSubdomainResult{
+		Subdomains: validatedDomains,
+	}
+
+	report := dnsfern.DiscoverDnsSubdomainReport{
+		Config: &config,
+		Result: &result,
+		Errors: errors,
+	}
+
+	return report, nil
+}
+
+// validateFQDNsWithCorrelation performs validation and wildcard detection for a list of FQDNs
+func validateFQDNsWithCorrelation(ctx context.Context, fqdns []string, threads int, timeout int, dnsResolvers []string) ([]string, error) {
+	log := svc1log.FromContext(ctx)
+
+	// Setup DNS resolvers
+	resolvers := []*net.Resolver{}
+	if len(dnsResolvers) == 0 {
+		// Use default resolver
+		resolvers = append(resolvers, &net.Resolver{})
+	} else {
+		for _, dnsServerAddress := range dnsResolvers {
+			resolvers = append(resolvers, utils.GetResolver(dnsServerAddress, log))
+		}
+	}
+
+	// Process FQDNs concurrently
+	validDomains := []string{}
+	validDomainsMutex := &sync.Mutex{}
+	var wg sync.WaitGroup
+	semaphore := make(chan struct{}, threads)
+
+	var resolverIndex int64 // For round robin resolver selection
+	var completedCount int64
+	totalDomains := len(fqdns)
+
+	log.Info("Starting FQDN correlation analysis", svc1log.SafeParam("total_fqdns", totalDomains))
+
+	for _, fqdn := range fqdns {
+		wg.Add(1)
+		go func(fqdn string) {
+			defer wg.Done()
+
+			select {
+			case semaphore <- struct{}{}:
+				defer func() { <-semaphore }()
+			case <-ctx.Done():
+				return
+			}
+
+			// Round robin resolver selection
+			currentIndex := atomic.AddInt64(&resolverIndex, 1) - 1
+			resolverIdx := currentIndex % int64(len(resolvers))
+			resolver := resolvers[resolverIdx]
+
+			isValid, hasWildcard, err := validateSingleFQDNCorrelation(ctx, fqdn, resolver, timeout, log)
+			if err != nil {
+				log.Error("Error validating FQDN",
+					svc1log.SafeParam("fqdn", fqdn),
+					svc1log.SafeParam("error", err.Error()))
+			}
+
+			completed := atomic.AddInt64(&completedCount, 1)
+
+			log.Info("FQDN correlation check",
+				svc1log.SafeParam("fqdn", fqdn),
+				svc1log.SafeParam("valid", isValid),
+				svc1log.SafeParam("wildcard", hasWildcard),
+				svc1log.SafeParam("completed", completed),
+				svc1log.SafeParam("total", totalDomains))
+
+			// Only include valid, non-wildcard domains in results
+			if isValid && !hasWildcard {
+				validDomainsMutex.Lock()
+				validDomains = append(validDomains, fqdn)
+				validDomainsMutex.Unlock()
+			}
+		}(fqdn)
+	}
+
+	wg.Wait()
+
+	log.Info("FQDN correlation analysis completed",
+		svc1log.SafeParam("total_processed", totalDomains),
+		svc1log.SafeParam("valid_domains", len(validDomains)))
+
+	return validDomains, nil
+}
+
+// validateSingleFQDNCorrelation validates a single FQDN and checks if it has wildcard DNS
+func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *net.Resolver, timeout int, log svc1log.Logger) (bool, bool, error) {
+	// Create timeout context for DNS lookup if specified
+	lookupCtx := ctx
+	var cancel context.CancelFunc
+	if timeout > 0 {
+		lookupCtx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+
+	// Try to resolve the FQDN
+	_, err := resolver.LookupHost(lookupCtx, fqdn)
+	if err != nil {
+		return false, false, fmt.Errorf("DNS resolution failed: %v", err)
+	}
+
+	// Check for wildcard DNS - test the full FQDN directly
+	wildcardDomain, err := detectWildcardForFullDomain(lookupCtx, fqdn, resolver)
+	if err != nil {
+		log.Warn("Failed to detect wildcard DNS",
+			svc1log.SafeParam("fqdn", fqdn),
+			svc1log.SafeParam("error", err.Error()))
+	} else if wildcardDomain != nil {
+		return true, true, nil
+	}
+
+	return true, false, nil
+}
+
+// detectWildcardForFullDomain tests if the given FQDN has wildcard DNS behavior
+// This tests the parent domain of the given FQDN to see if it has wildcard records
+func detectWildcardForFullDomain(ctx context.Context, fqdn string, resolver *net.Resolver) (*string, error) {
+	// Extract the parent domain to test for wildcards
+	// e.g., for "api.example.com", test if "example.com" has wildcard behavior
+	parts := strings.Split(fqdn, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid FQDN format for wildcard detection")
+	}
+
+	// Get parent domain (remove first subdomain)
+	if len(parts) == 2 {
+		// This is already a root domain, test it directly
+		return detectWildcardDNS(ctx, fqdn, resolver)
+	}
+
+	// Get parent domain by removing the first part
+	parentDomain := strings.Join(parts[1:], ".")
+	return detectWildcardDNS(ctx, parentDomain, resolver)
+}


### PR DESCRIPTION
### TL;DR

Added a new subdomain correlation command to discover and validate subdomains across multiple domains.

Not worth using the Active Cmd, will be more straight foward in the compiler now

### What changed?

- Added a new `correlation` subcommand to the `discover dns subdomain` command
- Implemented the `GetDomainSubdomainsCorrelation` function to perform FQDN validation and wildcard detection
- Created supporting functions for validating FQDNs with correlation
- Added a new `CORRELATION` enum value to replace `INTELLIGENT` in the subdomain discovery types
- Reorganized the command structure to include the new correlation command