### PR TITLE
Add Full wildcard check

### DIFF
--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -43,28 +43,6 @@ func GetDomainSubdomainsActive(ctx context.Context, config dnsfern.DiscoverDnsSu
 	return report, nil
 }
 
-// detectWildcardDNS tests a random high-entropy subdomain to check if a wildcard DNS record is present.
-// Returns the wildcard domain if detected, otherwise nil.
-func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolver) (*string, error) {
-	// Generate a high-entropy 16-character random subdomain
-	randomSubdomain, err := generateRandomSubdomain(domain)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check if the random subdomain resolves
-	_, err = resolver.LookupHost(ctx, randomSubdomain)
-
-	// If no error, it resolved, meaning wildcard is present
-	if err == nil {
-		wildcardDomain := "*." + domain
-		return &wildcardDomain, nil
-	}
-
-	// If the error is NXDOMAIN or SERVFAIL, wildcard is NOT present
-	return nil, nil
-}
-
 // getSubdomainsActive performs recursive bruteforce subdomain enumeration with concurrency and wildcard detection.
 func getSubdomainsActive(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, dnsServerAddresses []string) ([]string, error) {
 	log := svc1log.FromContext(ctx)
@@ -86,7 +64,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 	// First iteration - test all base subdomains for wildcards
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
-	wildcardDNS, err := detectWildcardDNS(ctx, domain, resolvers[0])
+	wildcardDNS, err := detectWildcardForFullDomain(ctx, domain, resolvers[0])
 	if err != nil {
 		return []string{}, err
 	}
@@ -117,7 +95,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 		validSubdomains := []string{}
 		for _, subdomain := range currentDepthSubdomains {
-			wildcardDNS, err := detectWildcardDNS(ctx, subdomain, resolvers[0]) // Use resolvers[0] for wildcard detection
+			wildcardDNS, err := detectWildcardForFullDomain(ctx, subdomain, resolvers[0]) // Use resolvers[0] for wildcard detection
 			if err != nil {
 				continue
 			}

--- a/internal/discover/dns/subdomain/correlation.go
+++ b/internal/discover/dns/subdomain/correlation.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -151,48 +150,4 @@ func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *n
 	}
 
 	return true, false, nil
-}
-
-// detectWildcardForFullDomain tests if the given FQDN has wildcard DNS behavior
-// This tests all parent domains of the given FQDN to see if any have wildcard records
-func detectWildcardForFullDomain(ctx context.Context, fqdn string, resolver *net.Resolver) (*string, error) {
-	// Extract all parent domains to test for wildcards
-	// e.g., for "api.staging.app.example.com", test:
-	// - "staging.app.example.com"
-	// - "app.example.com"
-	// - "example.com"
-	parts := strings.Split(fqdn, ".")
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid FQDN format for wildcard detection")
-	}
-
-	// If this is already a root domain, test it directly
-	if len(parts) == 2 {
-		return detectWildcardDNS(ctx, fqdn, resolver)
-	}
-
-	// Check each parent domain level for wildcards
-	// Start from the immediate parent and work up to the root domain
-	for i := 1; i < len(parts); i++ {
-		parentDomain := strings.Join(parts[i:], ".")
-
-		// Skip if we've reached a single-part domain (invalid)
-		if len(strings.Split(parentDomain, ".")) < 2 {
-			continue
-		}
-
-		wildcardDomain, err := detectWildcardDNS(ctx, parentDomain, resolver)
-		if err != nil {
-			// Log the error but continue checking other parent domains
-			continue
-		}
-
-		// If we found a wildcard, return it immediately
-		if wildcardDomain != nil {
-			return wildcardDomain, nil
-		}
-	}
-
-	// No wildcards found in any parent domain
-	return nil, nil
 }

--- a/internal/discover/dns/subdomain/correlation.go
+++ b/internal/discover/dns/subdomain/correlation.go
@@ -144,6 +144,9 @@ func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *n
 			svc1log.SafeParam("fqdn", fqdn),
 			svc1log.SafeParam("error", err.Error()))
 	} else if wildcardDomain != nil {
+		log.Info("Wildcard DNS detected",
+			svc1log.SafeParam("fqdn", fqdn),
+			svc1log.SafeParam("wildcard_domain", *wildcardDomain))
 		return true, true, nil
 	}
 
@@ -151,22 +154,45 @@ func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *n
 }
 
 // detectWildcardForFullDomain tests if the given FQDN has wildcard DNS behavior
-// This tests the parent domain of the given FQDN to see if it has wildcard records
+// This tests all parent domains of the given FQDN to see if any have wildcard records
 func detectWildcardForFullDomain(ctx context.Context, fqdn string, resolver *net.Resolver) (*string, error) {
-	// Extract the parent domain to test for wildcards
-	// e.g., for "api.example.com", test if "example.com" has wildcard behavior
+	// Extract all parent domains to test for wildcards
+	// e.g., for "api.staging.app.example.com", test:
+	// - "staging.app.example.com"
+	// - "app.example.com"
+	// - "example.com"
 	parts := strings.Split(fqdn, ".")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("invalid FQDN format for wildcard detection")
 	}
 
-	// Get parent domain (remove first subdomain)
+	// If this is already a root domain, test it directly
 	if len(parts) == 2 {
-		// This is already a root domain, test it directly
 		return detectWildcardDNS(ctx, fqdn, resolver)
 	}
 
-	// Get parent domain by removing the first part
-	parentDomain := strings.Join(parts[1:], ".")
-	return detectWildcardDNS(ctx, parentDomain, resolver)
+	// Check each parent domain level for wildcards
+	// Start from the immediate parent and work up to the root domain
+	for i := 1; i < len(parts); i++ {
+		parentDomain := strings.Join(parts[i:], ".")
+
+		// Skip if we've reached a single-part domain (invalid)
+		if len(strings.Split(parentDomain, ".")) < 2 {
+			continue
+		}
+
+		wildcardDomain, err := detectWildcardDNS(ctx, parentDomain, resolver)
+		if err != nil {
+			// Log the error but continue checking other parent domains
+			continue
+		}
+
+		// If we found a wildcard, return it immediately
+		if wildcardDomain != nil {
+			return wildcardDomain, nil
+		}
+	}
+
+	// No wildcards found in any parent domain
+	return nil, nil
 }

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -1,0 +1,75 @@
+package subdomain
+
+import (
+	// standard
+	"context"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// detectWildcardDNS tests a random high-entropy subdomain to check if a wildcard DNS record is present.
+// Returns the wildcard domain if detected, otherwise nil.
+func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolver) (*string, error) {
+	// Generate a high-entropy 16-character random subdomain
+	randomSubdomain, err := generateRandomSubdomain(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the random subdomain resolves
+	_, err = resolver.LookupHost(ctx, randomSubdomain)
+
+	// If no error, it resolved, meaning wildcard is present
+	if err == nil {
+		wildcardDomain := "*." + domain
+		return &wildcardDomain, nil
+	}
+
+	// If the error is NXDOMAIN or SERVFAIL, wildcard is NOT present
+	return nil, nil
+}
+
+// detectWildcardForFullDomain tests if the given FQDN has wildcard DNS behavior
+// This tests all parent domains of the given FQDN to see if any have wildcard records
+func detectWildcardForFullDomain(ctx context.Context, fqdn string, resolver *net.Resolver) (*string, error) {
+	// Extract all parent domains to test for wildcards
+	// e.g., for "api.staging.app.example.com", test:
+	// - "staging.app.example.com"
+	// - "app.example.com"
+	// - "example.com"
+	parts := strings.Split(fqdn, ".")
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("invalid FQDN format for wildcard detection")
+	}
+
+	// If this is already a root domain, test it directly
+	if len(parts) == 2 {
+		return detectWildcardDNS(ctx, fqdn, resolver)
+	}
+
+	// Check each parent domain level for wildcards
+	// Start from the immediate parent and work up to the root domain
+	for i := 1; i < len(parts); i++ {
+		parentDomain := strings.Join(parts[i:], ".")
+
+		// Skip if we've reached a single-part domain (invalid)
+		if len(strings.Split(parentDomain, ".")) < 2 {
+			continue
+		}
+
+		wildcardDomain, err := detectWildcardDNS(ctx, parentDomain, resolver)
+		if err != nil {
+			// Log the error but continue checking other parent domains
+			continue
+		}
+
+		// If we found a wildcard, return it immediately
+		if wildcardDomain != nil {
+			return wildcardDomain, nil
+		}
+	}
+
+	// No wildcards found in any parent domain
+	return nil, nil
+}


### PR DESCRIPTION
### TL;DR

Improved wildcard DNS detection by checking all parent domains instead of just the immediate parent.

### What changed?

Enhanced the `detectWildcardForFullDomain` function to check all parent domains of a given FQDN for wildcard DNS behavior, rather than only checking the immediate parent domain. For example, when checking "[api.staging.app.example.com](http://api.staging.app.example.com)", the function now tests "[staging.app.example.com](http://staging.app.example.com)", "[app.example.com](http://app.example.com)", and "[example.com](http://example.com)" sequentially until it finds a wildcard or exhausts all options.