### PR TITLE
DNS Correlation: Timeout Bug Fix

### DIFF
--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -2,9 +2,7 @@ package subdomain
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
-	"math/big"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -195,22 +193,6 @@ func generatePermutations(validSubdomains []string, subdomainList []string) []st
 		}
 	}
 	return results
-}
-
-// generateRandomSubdomain generates a high-entropy subdomain with only letters (16 characters).
-func generateRandomSubdomain(domain string) (string, error) {
-	letterBytes := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-
-	randomString := make([]byte, 16)
-	for i := range randomString {
-		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
-		if err != nil {
-			return "", err
-		}
-		randomString[i] = letterBytes[n.Int64()]
-	}
-
-	return fmt.Sprintf("%s.%s", string(randomString), domain), nil
 }
 
 // GetDiscoverDNSSubdomainActiveWordlistPath returns the file path for a given wordlist size

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -64,7 +64,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 	// First iteration - test all base subdomains for wildcards
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
-	wildcardDNS, err := detectWildcardForFullDomain(ctx, domain, resolvers[0])
+	wildcardDNS, err := detectWildcardDNS(ctx, domain, resolvers[0])
 	if err != nil {
 		return []string{}, err
 	}
@@ -95,7 +95,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 		validSubdomains := []string{}
 		for _, subdomain := range currentDepthSubdomains {
-			wildcardDNS, err := detectWildcardForFullDomain(ctx, subdomain, resolvers[0]) // Use resolvers[0] for wildcard detection
+			wildcardDNS, err := detectWildcardDNS(ctx, subdomain, resolvers[0]) // Use resolvers[0] for wildcard detection
 			if err != nil {
 				continue
 			}

--- a/internal/discover/dns/subdomain/correlation.go
+++ b/internal/discover/dns/subdomain/correlation.go
@@ -86,7 +86,7 @@ func validateFQDNsWithCorrelation(ctx context.Context, fqdns []string, threads i
 			resolverIdx := currentIndex % int64(len(resolvers))
 			resolver := resolvers[resolverIdx]
 
-			isValid, hasWildcard, err := validateSingleFQDNCorrelation(ctx, fqdn, resolver, timeout, log)
+			isValid, err := validateSingleFQDNCorrelation(ctx, fqdn, resolver, timeout, log)
 			if err != nil {
 				log.Error("Error validating FQDN",
 					svc1log.SafeParam("fqdn", fqdn),
@@ -98,12 +98,11 @@ func validateFQDNsWithCorrelation(ctx context.Context, fqdns []string, threads i
 			log.Info("FQDN correlation check",
 				svc1log.SafeParam("fqdn", fqdn),
 				svc1log.SafeParam("valid", isValid),
-				svc1log.SafeParam("wildcard", hasWildcard),
 				svc1log.SafeParam("completed", completed),
 				svc1log.SafeParam("total", totalDomains))
 
 			// Only include valid, non-wildcard domains in results
-			if isValid && !hasWildcard {
+			if isValid {
 				validDomainsMutex.Lock()
 				validDomains = append(validDomains, fqdn)
 				validDomainsMutex.Unlock()
@@ -121,7 +120,11 @@ func validateFQDNsWithCorrelation(ctx context.Context, fqdns []string, threads i
 }
 
 // validateSingleFQDNCorrelation validates a single FQDN and checks if it has wildcard DNS
-func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *net.Resolver, timeout int, log svc1log.Logger) (bool, bool, error) {
+// Returns:
+// - isValid: true if the FQDN is valid
+// - hasWildcard: true if the FQDN has wildcard DNS
+// - err: error if the FQDN is invalid
+func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *net.Resolver, timeout int, log svc1log.Logger) (bool, error) {
 	// Create timeout context for DNS lookup if specified
 	lookupCtx := ctx
 	var cancel context.CancelFunc
@@ -133,21 +136,22 @@ func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *n
 	// Try to resolve the FQDN
 	_, err := resolver.LookupHost(lookupCtx, fqdn)
 	if err != nil {
-		return false, false, fmt.Errorf("DNS resolution failed: %v", err)
+		return false, fmt.Errorf("DNS resolution failed: %v", err)
 	}
 
 	// Check for wildcard DNS - test the full FQDN directly
-	wildcardDomain, err := detectWildcardForFullDomain(lookupCtx, fqdn, resolver)
+	wildcardDomain, err := detectWildcardDNS(lookupCtx, fqdn, resolver)
 	if err != nil {
 		log.Warn("Failed to detect wildcard DNS",
 			svc1log.SafeParam("fqdn", fqdn),
 			svc1log.SafeParam("error", err.Error()))
+		return false, fmt.Errorf("wildcard detection failed: %v", err)
 	} else if wildcardDomain != nil {
 		log.Info("Wildcard DNS detected",
 			svc1log.SafeParam("fqdn", fqdn),
 			svc1log.SafeParam("wildcard_domain", *wildcardDomain))
-		return true, true, nil
+		return false, nil
 	}
 
-	return true, false, nil
+	return true, nil
 }

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -3,9 +3,7 @@ package subdomain
 import (
 	// standard
 	"context"
-	"fmt"
 	"net"
-	"strings"
 )
 
 // detectWildcardDNS tests a random high-entropy subdomain to check if a wildcard DNS record is present.
@@ -27,49 +25,5 @@ func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolve
 	}
 
 	// If the error is NXDOMAIN or SERVFAIL, wildcard is NOT present
-	return nil, nil
-}
-
-// detectWildcardForFullDomain tests if the given FQDN has wildcard DNS behavior
-// This tests all parent domains of the given FQDN to see if any have wildcard records
-func detectWildcardForFullDomain(ctx context.Context, fqdn string, resolver *net.Resolver) (*string, error) {
-	// Extract all parent domains to test for wildcards
-	// e.g., for "api.staging.app.example.com", test:
-	// - "staging.app.example.com"
-	// - "app.example.com"
-	// - "example.com"
-	parts := strings.Split(fqdn, ".")
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid FQDN format for wildcard detection")
-	}
-
-	// If this is already a root domain, test it directly
-	if len(parts) == 2 {
-		return detectWildcardDNS(ctx, fqdn, resolver)
-	}
-
-	// Check each parent domain level for wildcards
-	// Start from the immediate parent and work up to the root domain
-	for i := 1; i < len(parts); i++ {
-		parentDomain := strings.Join(parts[i:], ".")
-
-		// Skip if we've reached a single-part domain (invalid)
-		if len(strings.Split(parentDomain, ".")) < 2 {
-			continue
-		}
-
-		wildcardDomain, err := detectWildcardDNS(ctx, parentDomain, resolver)
-		if err != nil {
-			// Log the error but continue checking other parent domains
-			continue
-		}
-
-		// If we found a wildcard, return it immediately
-		if wildcardDomain != nil {
-			return wildcardDomain, nil
-		}
-	}
-
-	// No wildcards found in any parent domain
 	return nil, nil
 }

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -3,6 +3,9 @@ package subdomain
 import (
 	// standard
 	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
 	"net"
 )
 
@@ -24,6 +27,22 @@ func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolve
 		return &wildcardDomain, nil
 	}
 
-	// If the error is NXDOMAIN or SERVFAIL, wildcard is NOT present
+	// If the error, domain didnt resolve so wildcard is NOT present
 	return nil, nil
+}
+
+// generateRandomSubdomain generates a high-entropy subdomain with only letters (16 characters).
+func generateRandomSubdomain(domain string) (string, error) {
+	letterBytes := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	randomString := make([]byte, 16)
+	for i := range randomString {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(letterBytes))))
+		if err != nil {
+			return "", err
+		}
+		randomString[i] = letterBytes[n.Int64()]
+	}
+
+	return fmt.Sprintf("%s.%s", string(randomString), domain), nil
 }


### PR DESCRIPTION
### TL;DR

Simplified wildcard DNS detection by removing redundant function and improving error handling.

### What changed?

- Removed the `detectWildcardForFullDomain` function and replaced all calls with the simpler `detectWildcardDNS` function
- Updated the `validateSingleFQDNCorrelation` function to:
    - Return only two values (isValid and error) instead of three
    - Improve error handling for wildcard detection
    - Return false for domains with wildcard DNS instead of true with a wildcard flag
- Updated the validation logic in `validateFQDNsWithCorrelation` to match the new function signature
- Removed unused imports (fmt and strings) from helpers.go