### PR TITLE
Split Reverse Forward Command

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -81,7 +81,8 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Subcommands:
 	// - certs
 	// - records
-	// - forward-reverse
+	// - forward
+	// - reverse
 	// - subdomain
 	//   - active
 	//   - correlation
@@ -160,10 +161,10 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSCmd.AddCommand(discoverDNSRecordsCmd)
 
 	// Forward-Reverse Command
-	discoverDNSForwardReverseCmd := &cobra.Command{
-		Use:   "forward-reverse",
-		Short: "Perform forward and reverse DNS lookups",
-		Long:  `Perform both forward and reverse DNS lookups for the specified domain to identify associated IPs and hostnames.`,
+	discoverDNSForwardCmd := &cobra.Command{
+		Use:   "forward",
+		Short: "Perform forward DNS lookups",
+		Long:  `Perform forward DNS lookups for the specified domain to identify associated IPs.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			domain, err := cmd.Flags().GetString("domain")
 			if err != nil {
@@ -177,22 +178,74 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			config := getDiscoverDNSForwardReverseConfig(domain, dnsResolvers)
+			config := getDiscoverDNSForwardConfig(domain, dnsResolvers)
 
-			report := dns.GetForwardReverseDNSLookup(config)
+			report := dns.GetForwardDNSLookup(config)
 			a.OutputSignal.Content = report
 		},
 	}
 
 	// Target Flags
-	discoverDNSForwardReverseCmd.Flags().String("domain", "", "The domain name to perform forward and reverse lookups on")
-	discoverDNSForwardReverseCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
+	discoverDNSForwardCmd.Flags().String("domain", "", "The domain name to perform forward lookups on")
+	discoverDNSForwardCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
 
 	// Mark Required Flags
-	_ = discoverDNSForwardReverseCmd.MarkFlagRequired("domain")
+	_ = discoverDNSForwardCmd.MarkFlagRequired("domain")
 
 	// Add command to 'dns' command
-	discoverDNSCmd.AddCommand(discoverDNSForwardReverseCmd)
+	discoverDNSCmd.AddCommand(discoverDNSForwardCmd)
+
+	// Reverse Command
+	discoverDNSReverseCmd := &cobra.Command{
+		Use:   "reverse",
+		Short: "Perform a reverse DNS lookup on a single IP, list of IPs, or a CIDR range",
+		Long:  `Perform a reverse DNS lookup on a single IP, list of IPs, or a CIDR range.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Target Flags
+			ips, err := cmd.Flags().GetStringSlice("ip-addresses")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			cidr, err := cmd.Flags().GetString("cidr")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			if len(ips) == 0 && cidr == "" {
+				a.OutputSignal.AddError(fmt.Errorf("either --ips or --cidr must be provided"))
+				return
+			}
+
+			// Config Flags
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			threads, err := cmd.Flags().GetInt("threads")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			// Create config
+			config := getDiscoverDNSReverseConfig(ips, cidr, dnsResolvers, threads)
+
+			// Create report
+			report := dns.GetReverseLookup(cmd.Context(), config)
+			a.OutputSignal.Content = report
+		},
+	}
+
+	// Target Flags
+	discoverDNSReverseCmd.Flags().StringSlice("ip-addresses", []string{}, "The IP addresses to perform reverse DNS lookup on")
+	discoverDNSReverseCmd.Flags().String("cidr", "", "The CIDR range to perform reverse DNS lookup on")
+	discoverDNSReverseCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
+	discoverDNSReverseCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning (Default is number of CPUS on machine)")
+
+	// Add command to 'dns' command
+	discoverDNSCmd.AddCommand(discoverDNSReverseCmd)
 
 	// subdomain Cmd
 	// Subcommands:
@@ -654,58 +707,6 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Add command to 'ip' command
 	discoverIPCmd.AddCommand(discoverIPDomainASNCmd)
 
-	// Reverse Command
-	discoverIPReverseCmd := &cobra.Command{
-		Use:   "reverse",
-		Short: "Perform a reverse DNS lookup on a single IP, list of IPs, or a CIDR range",
-		Long:  `Perform a reverse DNS lookup on a single IP, list of IPs, or a CIDR range.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// Target Flags
-			ips, err := cmd.Flags().GetStringSlice("ip-addresses")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			cidr, err := cmd.Flags().GetString("cidr")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			if len(ips) == 0 && cidr == "" {
-				a.OutputSignal.AddError(fmt.Errorf("either --ips or --cidr must be provided"))
-				return
-			}
-
-			// Config Flags
-			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-			threads, err := cmd.Flags().GetInt("threads")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
-
-			// Create config
-			config := getDiscoverIPReverseConfig(ips, cidr, dnsResolvers, threads)
-
-			// Create report
-			report := ip.GetReverseLookup(cmd.Context(), config)
-			a.OutputSignal.Content = report
-		},
-	}
-
-	// Target Flags
-	discoverIPReverseCmd.Flags().StringSlice("ip-addresses", []string{}, "The IP addresses to perform reverse DNS lookup on")
-	discoverIPReverseCmd.Flags().String("cidr", "", "The CIDR range to perform reverse DNS lookup on")
-	discoverIPReverseCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)")
-	discoverIPReverseCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning (Default is number of CPUS on machine)")
-
-	// Add command to 'ip' command
-	discoverIPCmd.AddCommand(discoverIPReverseCmd)
-
 	// Add the 'discover' command to the root command
 	a.RootCmd.AddCommand(discoverCmd)
 }
@@ -732,12 +733,25 @@ func getDiscoverDNSRecordsConfig(domain string) dnsfern.DiscoverDnsRecordsConfig
 	}
 }
 
-// getDiscoverDNSForwardReverseConfig creates and returns a configuration for forward/reverse DNS lookup
-func getDiscoverDNSForwardReverseConfig(domain string, dnsResolvers []string) dnsfern.DiscoverDnsForwardReverseConfig {
-	return dnsfern.DiscoverDnsForwardReverseConfig{
+// getDiscoverDNSForwardConfig creates and returns a configuration for forward DNS lookup
+func getDiscoverDNSForwardConfig(domain string, dnsResolvers []string) dnsfern.DiscoverDnsForwardConfig {
+	return dnsfern.DiscoverDnsForwardConfig{
 		Domain:       domain,
 		DnsResolvers: dnsResolvers,
 	}
+}
+
+// getDiscoverDNSReverseConfig creates and returns a configuration for DNS reverse lookup
+func getDiscoverDNSReverseConfig(ips []string, cidr string, dnsResolvers []string, threads int) *dnsfern.DiscoverDnsReverseConfig {
+	config := &dnsfern.DiscoverDnsReverseConfig{
+		IpAddresses:  ips,
+		DnsResolvers: dnsResolvers,
+		Threads:      max(threads, 0),
+	}
+	if cidr != "" {
+		config.Cidr = &cidr
+	}
+	return config
 }
 
 // getDiscoverDNSActiveSubdomainConfig creates and returns a configuration for active subdomain discovery
@@ -807,18 +821,5 @@ func getDiscoverIPDomainASNConfig(ips []string, cidr string, dnsResolvers []stri
 		config.Cidr = &cidr
 	}
 
-	return config
-}
-
-// getDiscoverIPReverseConfig creates and returns a configuration for IP reverse DNS lookup
-func getDiscoverIPReverseConfig(ips []string, cidr string, dnsResolvers []string, threads int) *ipfern.DiscoverIpReverseConfig {
-	config := &ipfern.DiscoverIpReverseConfig{
-		IpAddresses:  ips,
-		DnsResolvers: dnsResolvers,
-		Threads:      max(threads, 0),
-	}
-	if cidr != "" {
-		config.Cidr = &cidr
-	}
 	return config
 }

--- a/fern/definition/discover/dns/forward.yml
+++ b/fern/definition/discover/dns/forward.yml
@@ -1,20 +1,20 @@
 types:
 # Config Struct
-  DiscoverDnsForwardReverseConfig:
+  DiscoverDnsForwardConfig:
     properties:
       domain: string
       dnsResolvers: optional<list<string>>
 # Result Structs
   LookupDetails:
     properties:
-      forwardIp: optional<string>
-      reversePtrs: optional<list<string>>
-  DiscoverDnsForwardReverseResult:
+      domain: string
+      ipAddress: optional<string>
+  DiscoverDnsForwardResult:
     properties:
       lookups: optional<list<LookupDetails>>
 # Report Struct
   DiscoverDnsForwardReverseReport:
     properties:
-      config: DiscoverDnsForwardReverseConfig
-      result: DiscoverDnsForwardReverseResult
+      config: DiscoverDnsForwardConfig
+      result: DiscoverDnsForwardResult
       errors: optional<list<string>>

--- a/fern/definition/discover/dns/reverse.yml
+++ b/fern/definition/discover/dns/reverse.yml
@@ -1,6 +1,6 @@
 types:
 # Config Struct
-  DiscoverIpReverseConfig:
+  DiscoverDnsReverseConfig:
     properties:
       ipAddresses: optional<list<string>>
       cidr: optional<string>
@@ -11,12 +11,12 @@ types:
     properties:
       ipAddress: string
       reverseDnsNames: list<string>
-  DiscoverIpReverseResult:
+  DiscoverDnsReverseResult:
     properties:
       lookups: optional<list<ReverseDetails>>
 # Report Structs
-  DiscoverIpReverseReport:
+  DiscoverDnsReverseReport:
     properties:
-      config: DiscoverIpReverseConfig
-      result: DiscoverIpReverseResult
+      config: DiscoverDnsReverseConfig
+      result: DiscoverDnsReverseResult
       errors: optional<list<string>>

--- a/internal/discover/dns/forward.go
+++ b/internal/discover/dns/forward.go
@@ -1,18 +1,22 @@
 package dns
 
 import (
+	// Standard
 	"context"
 	"math/rand"
 	"net"
 
+	// Generated
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
+	// Utils
 	"github.com/Method-Security/osintscan/utils"
+	// External
 	svc1log "github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
-// GetForwardReverseDNSLookup performs both forward (A/AAAA) and reverse (PTR) DNS lookups for a given FQDN.
-// Returns a report containing all resolved IPs and their associated hostnames, along with any errors encountered.
-func GetForwardReverseDNSLookup(config dnsfern.DiscoverDnsForwardReverseConfig) dnsfern.DiscoverDnsForwardReverseReport {
+// GetForwardDNSLookup performs forward (A/AAAA) DNS lookups for a given FQDN.
+// Returns a report containing all resolved IPs, along with any errors encountered.
+func GetForwardDNSLookup(config dnsfern.DiscoverDnsForwardConfig) dnsfern.DiscoverDnsForwardReverseReport {
 	errors := []string{}
 
 	lookUps, errs := getLookups(config.Domain, config.DnsResolvers)
@@ -20,7 +24,7 @@ func GetForwardReverseDNSLookup(config dnsfern.DiscoverDnsForwardReverseConfig) 
 		errors = append(errors, errs...)
 	}
 
-	results := dnsfern.DiscoverDnsForwardReverseResult{
+	results := dnsfern.DiscoverDnsForwardResult{
 		Lookups: lookUps,
 	}
 
@@ -54,16 +58,10 @@ func getLookups(domain string, dnsResolvers []string) ([]*dnsfern.LookupDetails,
 			continue
 		}
 
-		// Perform a reverse lookup (PTR record) for each IP
-		names, err := resolver.LookupAddr(ctx, ip.String())
-		if err != nil {
-			errors = append(errors, err.Error())
-		}
-
-		// Store resolved hostnames per IP
+		// Store domain and IP address for each resolved IP
 		lookUps = append(lookUps, &dnsfern.LookupDetails{
-			ForwardIp:   &ipStr,
-			ReversePtrs: names,
+			Domain:    domain,
+			IpAddress: &ipStr,
 		})
 	}
 

--- a/internal/discover/dns/reverse.go
+++ b/internal/discover/dns/reverse.go
@@ -1,4 +1,4 @@
-package ip
+package dns
 
 import (
 	"context"
@@ -8,13 +8,13 @@ import (
 	"sync"
 	"sync/atomic"
 
-	ipfern "github.com/Method-Security/osintscan/generated/go/discover/ip"
+	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
 	"github.com/Method-Security/osintscan/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 // GetReverseLookup performs reverse DNS lookups for a list of IP addresses
-func GetReverseLookup(ctx context.Context, config *ipfern.DiscoverIpReverseConfig) *ipfern.DiscoverIpReverseReport {
+func GetReverseLookup(ctx context.Context, config *dnsfern.DiscoverDnsReverseConfig) *dnsfern.DiscoverDnsReverseReport {
 	log := svc1log.FromContext(ctx)
 	errors := []string{}
 
@@ -22,9 +22,9 @@ func GetReverseLookup(ctx context.Context, config *ipfern.DiscoverIpReverseConfi
 	allIPs, err := explodeIPsFromReverseConfig(config)
 	if err != nil {
 		errors = append(errors, err.Error())
-		return &ipfern.DiscoverIpReverseReport{
+		return &dnsfern.DiscoverDnsReverseReport{
 			Config: config,
-			Result: &ipfern.DiscoverIpReverseResult{},
+			Result: &dnsfern.DiscoverDnsReverseResult{},
 			Errors: errors,
 		}
 	}
@@ -47,7 +47,7 @@ func GetReverseLookup(ctx context.Context, config *ipfern.DiscoverIpReverseConfi
 		errors = append(errors, lookupErrors...)
 	}
 
-	result := &ipfern.DiscoverIpReverseResult{
+	result := &dnsfern.DiscoverDnsReverseResult{
 		Lookups: lookups,
 	}
 
@@ -55,7 +55,7 @@ func GetReverseLookup(ctx context.Context, config *ipfern.DiscoverIpReverseConfi
 		svc1log.SafeParam("total_lookups", len(lookups)),
 		svc1log.SafeParam("errors", len(errors)))
 
-	return &ipfern.DiscoverIpReverseReport{
+	return &dnsfern.DiscoverDnsReverseReport{
 		Config: config,
 		Result: result,
 		Errors: errors,
@@ -63,19 +63,19 @@ func GetReverseLookup(ctx context.Context, config *ipfern.DiscoverIpReverseConfi
 }
 
 // explodeIPsFromReverseConfig extracts and expands all IPs from the reverse configuration
-func explodeIPsFromReverseConfig(config *ipfern.DiscoverIpReverseConfig) ([]string, error) {
+func explodeIPsFromReverseConfig(config *dnsfern.DiscoverDnsReverseConfig) ([]string, error) {
 	return utils.ExplodeIPsFromAddressesAndCIDR(config.IpAddresses, config.Cidr)
 }
 
 // performConcurrentReverseLookups performs reverse DNS lookups concurrently using round-robin resolver selection
-func performConcurrentReverseLookups(ctx context.Context, ips []string, dnsResolvers []string, threads int) ([]*ipfern.ReverseDetails, []string) {
+func performConcurrentReverseLookups(ctx context.Context, ips []string, dnsResolvers []string, threads int) ([]*dnsfern.ReverseDetails, []string) {
 	log := svc1log.FromContext(ctx)
 	maxWorkers := threads // Use configured thread count for concurrency control
 	if maxWorkers == 0 {
 		maxWorkers = runtime.NumCPU()
 	}
 
-	lookups := make([]*ipfern.ReverseDetails, 0, len(ips))
+	lookups := make([]*dnsfern.ReverseDetails, 0, len(ips))
 	errors := []string{}
 	lookupsMutex := &sync.Mutex{}
 	errorsMutex := &sync.Mutex{}
@@ -130,7 +130,7 @@ func performConcurrentReverseLookups(ctx context.Context, ips []string, dnsResol
 }
 
 // performSingleReverseLookup performs a reverse DNS lookup for a single IP address
-func performSingleReverseLookup(ctx context.Context, ip string, resolver *net.Resolver) (*ipfern.ReverseDetails, error) {
+func performSingleReverseLookup(ctx context.Context, ip string, resolver *net.Resolver) (*dnsfern.ReverseDetails, error) {
 	// Perform reverse DNS lookup to get all PTR records
 	names, err := resolver.LookupAddr(ctx, ip)
 	if err != nil {
@@ -138,7 +138,7 @@ func performSingleReverseLookup(ctx context.Context, ip string, resolver *net.Re
 		return nil, fmt.Errorf("reverse DNS lookup failed: %w", err)
 	}
 
-	lookup := &ipfern.ReverseDetails{
+	lookup := &dnsfern.ReverseDetails{
 		IpAddress: ip,
 	}
 


### PR DESCRIPTION
### TL;DR

Split the DNS forward-reverse lookup command into separate forward and reverse commands for more granular control.

### What changed?

- Split the `forward-reverse` DNS command into two separate commands:
  - `forward`: Performs only forward DNS lookups to identify IPs associated with a domain
  - `reverse`: Performs reverse DNS lookups on IP addresses or CIDR ranges
- Moved the reverse DNS lookup functionality from the `ip` package to the `dns` package
- Updated the corresponding configuration types and result structures
- Set default DNS resolver to `1.1.1.1:53` for both commands
- Simplified the forward lookup to only return domain and IP address pairs without reverse lookups
