### PR TITLE
Add Record Type Parameter to DNS Record CLI

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -160,7 +160,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Target Flags
 	discoverDNSRecordsCmd.Flags().String("domain", "", "The domain name to query for DNS records")
-	discoverDNSRecordsCmd.Flags().StringSlice("record-types", []string{"ALL"}, "Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, UNKNOWN, ALL)")
+	discoverDNSRecordsCmd.Flags().StringSlice("record-types", []string{"ALL"}, "Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, ALL)")
 
 	// Mark Required Flags
 	_ = discoverDNSRecordsCmd.MarkFlagRequired("domain")

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	// Generated
+	common "github.com/Method-Security/osintscan/generated/go/common"
 	asnfern "github.com/Method-Security/osintscan/generated/go/discover/asn"
 	cdnfern "github.com/Method-Security/osintscan/generated/go/discover/cdn"
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
@@ -140,7 +141,13 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 
-			config := getDiscoverDNSRecordsConfig(domain)
+			recordTypes, err := cmd.Flags().GetStringSlice("record-types")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			config := getDiscoverDNSRecordsConfig(domain, recordTypes)
 
 			report, err := dns.DiscoverDomainDNSRecords(cmd.Context(), config)
 			if err != nil {
@@ -153,6 +160,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Target Flags
 	discoverDNSRecordsCmd.Flags().String("domain", "", "The domain name to query for DNS records")
+	discoverDNSRecordsCmd.Flags().StringSlice("record-types", []string{"ALL"}, "Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, UNKNOWN, ALL)")
 
 	// Mark Required Flags
 	_ = discoverDNSRecordsCmd.MarkFlagRequired("domain")
@@ -733,9 +741,18 @@ func getDiscoverDNSCertsConfig(domain string) dnsfern.DiscoverDnsCertsConfig {
 }
 
 // getDiscoverDNSRecordsConfig creates and returns a configuration for DNS records discovery
-func getDiscoverDNSRecordsConfig(domain string) dnsfern.DiscoverDnsRecordsConfig {
+func getDiscoverDNSRecordsConfig(domain string, recordTypes []string) dnsfern.DiscoverDnsRecordsConfig {
+	// Convert string slice to DnsRecordType slice
+	var dnsRecordTypes []common.DnsRecordType
+	for _, recordType := range recordTypes {
+		if recordTypeEnum, err := common.NewDnsRecordTypeFromString(recordType); err == nil {
+			dnsRecordTypes = append(dnsRecordTypes, recordTypeEnum)
+		}
+	}
+
 	return dnsfern.DiscoverDnsRecordsConfig{
-		Domain: domain,
+		Domain:      domain,
+		RecordTypes: dnsRecordTypes,
 	}
 }
 

--- a/fern/definition/common/dns.yml
+++ b/fern/definition/common/dns.yml
@@ -3,13 +3,14 @@ types:
     enum:
       - A
       - AAAA
+      - CAA
       - CNAME
       - MX
       - NS
-      - SOA
-      - TXT
       - PTR
+      - SOA
       - SRV
+      - TXT
       - UNKNOWN
       - ALL
   DnsRecord:

--- a/fern/definition/common/dns.yml
+++ b/fern/definition/common/dns.yml
@@ -11,6 +11,7 @@ types:
       - PTR
       - SRV
       - UNKNOWN
+      - ALL
   DnsRecord:
     properties:
       name: string

--- a/fern/definition/discover/dns/records.yml
+++ b/fern/definition/discover/dns/records.yml
@@ -5,6 +5,7 @@ types:
   DiscoverDnsRecordsConfig:
     properties:
       domain: string
+      recordTypes: list<dns.DnsRecordType>
   DiscoverDnsRecordsResult:
     properties:
       dnsRecords: optional<list<dns.DnsRecord>>

--- a/internal/discover/dns/records.go
+++ b/internal/discover/dns/records.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"context"
+	"fmt"
 	"slices"
 
 	common "github.com/Method-Security/osintscan/generated/go/common"
@@ -9,6 +10,37 @@ import (
 	"github.com/miekg/dns"
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 )
+
+// filterDNSRecordsByType filters DNS records based on the requested record types
+func filterDNSRecordsByType(records []*common.DnsRecord, recordTypes []common.DnsRecordType) []*common.DnsRecord {
+	// If no specific types requested or ALL is requested, return everything
+	for _, recordType := range recordTypes {
+		if recordType == common.DnsRecordTypeAll {
+			return records
+		}
+	}
+
+	// If no types specified, return everything
+	if len(recordTypes) == 0 {
+		return records
+	}
+
+	// Create a set of requested types for quick lookup
+	requestedTypes := make(map[common.DnsRecordType]bool)
+	for _, recordType := range recordTypes {
+		requestedTypes[recordType] = true
+	}
+
+	// Filter records
+	var filteredRecords []*common.DnsRecord
+	for _, record := range records {
+		if requestedTypes[record.Type] {
+			filteredRecords = append(filteredRecords, record)
+		}
+	}
+
+	return filteredRecords
+}
 
 // getDNSRecords queries DNS for the specified record types for a domain and returns a DnsRecords struct.
 func getDNSRecords(domain string, questionTypes []uint16) ([]*common.DnsRecord, error) {
@@ -67,6 +99,15 @@ func getDNSRecords(domain string, questionTypes []uint16) ([]*common.DnsRecord, 
 	if slices.Contains(questionTypes, dns.TypeSRV) {
 		dnsRecords = append(dnsRecords, populateRecords(results.SRV, "SRV")...)
 	}
+	if slices.Contains(questionTypes, dns.TypeSOA) {
+		// SOA records have a different structure, need to convert them to strings
+		var soaStrings []string
+		for _, soa := range results.SOA {
+			soaString := fmt.Sprintf("%s %s %d %d %d %d %d", soa.NS, soa.Mbox, soa.Serial, soa.Refresh, soa.Retry, soa.Expire, soa.Minttl)
+			soaStrings = append(soaStrings, soaString)
+		}
+		dnsRecords = append(dnsRecords, populateRecords(soaStrings, "SOA")...)
+	}
 
 	return dnsRecords, nil
 }
@@ -76,12 +117,15 @@ func getDNSRecords(domain string, questionTypes []uint16) ([]*common.DnsRecord, 
 func DiscoverDomainDNSRecords(ctx context.Context, config dnsfern.DiscoverDnsRecordsConfig) (*dnsfern.DiscoverDnsRecordsReport, error) {
 	errors := []string{}
 
-	// Get all the DNS records
-	questionTypes := []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeMX, dns.TypeTXT, dns.TypeNS, dns.TypeCNAME, dns.TypePTR, dns.TypeSRV}
-	dnsRecords, err := getDNSRecords(config.Domain, questionTypes)
+	// Get all the DNS records (query all types, then filter)
+	questionTypes := []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeMX, dns.TypeTXT, dns.TypeNS, dns.TypeCNAME, dns.TypePTR, dns.TypeSRV, dns.TypeSOA}
+	allDNSRecords, err := getDNSRecords(config.Domain, questionTypes)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
+
+	// Filter DNS records based on requested types
+	dnsRecords := filterDNSRecordsByType(allDNSRecords, config.RecordTypes)
 
 	// The DMARC record is always in the _dmarc subdomain (RFC-7489)
 	dmarcRecords, err := getDNSRecords("_dmarc."+config.Domain, []uint16{dns.TypeTXT})

--- a/internal/discover/dns/records.go
+++ b/internal/discover/dns/records.go
@@ -74,12 +74,15 @@ func getDNSRecords(domain string, questionTypes []uint16) ([]*common.DnsRecord, 
 		return dnsRecordsSlice
 	}
 
-	// Populate each record type if requested
+	// Populate each record type if requested (in alphabetical order)
 	if slices.Contains(questionTypes, dns.TypeA) {
 		dnsRecords = append(dnsRecords, populateRecords(results.A, "A")...)
 	}
 	if slices.Contains(questionTypes, dns.TypeAAAA) {
 		dnsRecords = append(dnsRecords, populateRecords(results.AAAA, "AAAA")...)
+	}
+	if slices.Contains(questionTypes, dns.TypeCAA) {
+		dnsRecords = append(dnsRecords, populateRecords(results.CAA, "CAA")...)
 	}
 	if slices.Contains(questionTypes, dns.TypeCNAME) {
 		dnsRecords = append(dnsRecords, populateRecords(results.CNAME, "CNAME")...)
@@ -90,14 +93,8 @@ func getDNSRecords(domain string, questionTypes []uint16) ([]*common.DnsRecord, 
 	if slices.Contains(questionTypes, dns.TypeNS) {
 		dnsRecords = append(dnsRecords, populateRecords(results.NS, "NS")...)
 	}
-	if slices.Contains(questionTypes, dns.TypeTXT) {
-		dnsRecords = append(dnsRecords, populateRecords(results.TXT, "TXT")...)
-	}
 	if slices.Contains(questionTypes, dns.TypePTR) {
 		dnsRecords = append(dnsRecords, populateRecords(results.PTR, "PTR")...)
-	}
-	if slices.Contains(questionTypes, dns.TypeSRV) {
-		dnsRecords = append(dnsRecords, populateRecords(results.SRV, "SRV")...)
 	}
 	if slices.Contains(questionTypes, dns.TypeSOA) {
 		// SOA records have a different structure, need to convert them to strings
@@ -107,6 +104,34 @@ func getDNSRecords(domain string, questionTypes []uint16) ([]*common.DnsRecord, 
 			soaStrings = append(soaStrings, soaString)
 		}
 		dnsRecords = append(dnsRecords, populateRecords(soaStrings, "SOA")...)
+	}
+	if slices.Contains(questionTypes, dns.TypeSRV) {
+		dnsRecords = append(dnsRecords, populateRecords(results.SRV, "SRV")...)
+	}
+	if slices.Contains(questionTypes, dns.TypeTXT) {
+		dnsRecords = append(dnsRecords, populateRecords(results.TXT, "TXT")...)
+	}
+
+	// Handle unknown record types by checking AllRecords for any records we didn't process
+	if len(results.AllRecords) > 0 {
+		// Create a set of processed records to avoid duplicates
+		processedRecords := make(map[string]bool)
+		for _, record := range dnsRecords {
+			processedRecords[record.Value] = true
+		}
+
+		// Check for unprocessed records in AllRecords
+		var unknownRecords []string
+		for _, record := range results.AllRecords {
+			if !processedRecords[record] {
+				unknownRecords = append(unknownRecords, record)
+			}
+		}
+
+		// Add unknown records with UNKNOWN type
+		if len(unknownRecords) > 0 {
+			dnsRecords = append(dnsRecords, populateRecords(unknownRecords, "UNKNOWN")...)
+		}
 	}
 
 	return dnsRecords, nil
@@ -118,7 +143,7 @@ func DiscoverDomainDNSRecords(ctx context.Context, config dnsfern.DiscoverDnsRec
 	errors := []string{}
 
 	// Get all the DNS records (query all types, then filter)
-	questionTypes := []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeMX, dns.TypeTXT, dns.TypeNS, dns.TypeCNAME, dns.TypePTR, dns.TypeSRV, dns.TypeSOA}
+	questionTypes := []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeCAA, dns.TypeCNAME, dns.TypeMX, dns.TypeNS, dns.TypePTR, dns.TypeSOA, dns.TypeSRV, dns.TypeTXT}
 	allDNSRecords, err := getDNSRecords(config.Domain, questionTypes)
 	if err != nil {
 		errors = append(errors, err.Error())

--- a/internal/discover/dns/records.go
+++ b/internal/discover/dns/records.go
@@ -112,27 +112,8 @@ func getDNSRecords(domain string, questionTypes []uint16) ([]*common.DnsRecord, 
 		dnsRecords = append(dnsRecords, populateRecords(results.TXT, "TXT")...)
 	}
 
-	// Handle unknown record types by checking AllRecords for any records we didn't process
-	if len(results.AllRecords) > 0 {
-		// Create a set of processed records to avoid duplicates
-		processedRecords := make(map[string]bool)
-		for _, record := range dnsRecords {
-			processedRecords[record.Value] = true
-		}
-
-		// Check for unprocessed records in AllRecords
-		var unknownRecords []string
-		for _, record := range results.AllRecords {
-			if !processedRecords[record] {
-				unknownRecords = append(unknownRecords, record)
-			}
-		}
-
-		// Add unknown records with UNKNOWN type
-		if len(unknownRecords) > 0 {
-			dnsRecords = append(dnsRecords, populateRecords(unknownRecords, "UNKNOWN")...)
-		}
-	}
+	// Note: We don't process unknown record types to avoid noise from DNS protocol overhead
+	// and non-existent subdomain responses
 
 	return dnsRecords, nil
 }


### PR DESCRIPTION
### TL;DR

Added support for filtering DNS record types when discovering DNS records.

### What changed?

- Added a new `--record-types` flag to the `discover dns-records` command that allows users to specify which DNS record types to query
- Added a new `ALL` DNS record type to the common DNS record types enum
- Updated the DNS records discovery configuration to include the record types parameter
- Implemented filtering logic to return only the requested DNS record types
- Added support for SOA record type in the DNS records discovery
