### PR TITLE
DNS Active: When DNS  Look Up due to Outside Constraints Quick Exit

### DIFF
--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -27,8 +27,14 @@ func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolve
 		return &wildcardDomain, nil
 	}
 
-	// If the error, domain didnt resolve so wildcard is NOT present
-	return nil, nil
+	// Check if it's specifically NXDOMAIN (domain doesn't exist)
+	if isDNSNotFound(err) {
+		// NXDOMAIN = no wildcard, safe to continue
+		return nil, nil
+	}
+
+	// Any other DNS error = fail fast, don't continue with potentially unreliable results
+	return nil, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
 }
 
 // generateRandomSubdomain generates a high-entropy subdomain with only letters (16 characters).
@@ -45,4 +51,22 @@ func generateRandomSubdomain(domain string) (string, error) {
 	}
 
 	return fmt.Sprintf("%s.%s", string(randomString), domain), nil
+}
+
+// isDNSNotFound checks if the error is specifically an NXDOMAIN (domain not found) error
+// using proper DNS error type checking instead of fragile string matching
+func isDNSNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	
+	// Check for DNS-specific error types
+	if dnsError, ok := err.(*net.DNSError); ok {
+		// NXDOMAIN: domain doesn't exist (safe to continue)
+		// IsNotFound indicates the name does not exist
+		return dnsError.IsNotFound
+	}
+	
+	// For non-DNS errors, treat as failure (not NXDOMAIN)
+	return false
 }


### PR DESCRIPTION
## Fix
 
Fixed a critical bug in wildcard DNS detection where DNS resolution failures (timeouts, network errors) were incorrectly treated as "no wildcard present", causing the tool to proceed with brute force enumeration and report false positive subdomains. The improved logic now distinguishes between legitimate NXDOMAIN responses (no wildcard) and actual DNS failures, failing fast on the latter to prevent unreliable results. This resolves issues where temporary DNS problems during wildcard detection led to incorrect subdomain discoveries being reported as valid findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Differentiate NXDOMAIN from other DNS errors in wildcard detection and fail fast on non-NXDOMAIN failures to avoid unreliable results.
> 
> - **DNS subdomain discovery** (`internal/discover/dns/subdomain/helpers.go`):
>   - Refines `detectWildcardDNS` to treat NXDOMAIN as "no wildcard" and return an error for other DNS failures.
>   - Adds `isDNSNotFound` helper for robust NXDOMAIN detection via `net.DNSError`.
>   - Improves error messaging with context on failed DNS lookups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8085d202382083f2e64e02928b6e2783d930dae2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->