### PR TITLE
Bump Fern

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -112,13 +112,16 @@ jobs:
           brew install libpcap docker
           echo "LD_LIBRARY_PATH=$(brew --prefix)/Cellar/libpcap/*/lib" >> $GITHUB_ENV
         if: matrix.os == 'macos-latest'
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         if: matrix.os == 'ubuntu-latest'
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
         if: matrix.os == 'ubuntu-latest'
+
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:
@@ -131,17 +134,20 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
+
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser-pro
@@ -150,6 +156,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-dist
@@ -166,35 +173,34 @@ jobs:
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@v10
-        with:
-          root-reserve-mb: 32768
-          remove-android: "true"
-          remove-docker-images: "true"
-          remove-dotnet: "true"
-          remove-haskell: "true"
       - name: Install Dependences
         run: sudo apt install libpcap-dev
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Show available Docker Buildx platforms
         run: echo ${{ steps.buildx.outputs.platforms }}
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3.5.0
+
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0.16.0
         with:
           syft-version: v1.17.0
+
       - name: Login to ghcr.io registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to docker.io registry
         uses: docker/login-action@v3
         with:
@@ -205,23 +211,28 @@ jobs:
         uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
+
       - name: Generate Fern Go Code
         run: |
           npm install -g fern-api
           fern generate --group local
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+
       - name: View Artifacts
         run: ls -al artifacts artifacts/*
+
       - name: Arrange Artifacts
         run: |
           mkdir -p output/build-linux_arm64/

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.20.0"
+  "version": "3.78.1"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -13,7 +13,7 @@ groups:
   pypi-local:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         output:
           location: local-file-system
           path: ../generated/python
@@ -21,7 +21,7 @@ groups:
   pypi-test:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodosintscan
         output:
@@ -33,7 +33,7 @@ groups:
   pypi:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.11.1
+        version: 1.11.2
         config:
           package_name: methodosintscan
         output:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI workflow changes affect the release/build pipeline (Docker/QEMU/buildx logins and artifact assembly), so failures could block publishing; Fern generator version bumps may also change generated SDK outputs.
> 
> **Overview**
> Bumps Fern CLI/config version (`fern/fern.config.json` `3.20.0` → `3.78.1`) and updates the Python Pydantic generator to `1.11.2` in `fern/generators.yml`.
> 
> Updates the reusable GitHub Actions build workflow to run Fern Go code generation during build jobs and to set up Docker/QEMU/buildx plus registry logins before builds; also removes the prior “maximize build space” step and adds artifact upload/download/arrangement to feed the final `goreleaser` publish step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 227bd83af9daa09589282efcbc6caf6a433d457d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->