### PR TITLE
Record Enum: Update Config Fern

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -148,9 +148,10 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 			for _, recordType := range recordTypes {
-				if _, err := common.NewDnsRecordTypeFromString(recordType); err == nil {
-				} else {
+				_, err := common.NewDnsRecordTypeFromString(recordType)
+				if err != nil {
 					a.OutputSignal.AddError(fmt.Errorf("invalid DNS record type: %s", recordType))
+					return
 				}
 			}
 

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -147,18 +147,15 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-
-			var dnsRecordTypes []common.DnsRecordType
 			for _, recordType := range recordTypes {
-				if recordTypeEnum, err := common.NewDnsRecordTypeFromString(recordType); err == nil {
-					dnsRecordTypes = append(dnsRecordTypes, recordTypeEnum)
+				if _, err := common.NewDnsRecordTypeFromString(recordType); err == nil {
 				} else {
 					a.OutputSignal.AddError(fmt.Errorf("invalid DNS record type: %s", recordType))
 				}
 			}
 
 			// Create config
-			config := getDiscoverDNSRecordsConfig(domain, dnsRecordTypes)
+			config := getDiscoverDNSRecordsConfig(domain, recordTypes)
 
 			// Create report
 			report := dns.DiscoverDomainDNSRecords(cmd.Context(), config)
@@ -779,7 +776,7 @@ func getDiscoverDNSCertsConfig(domain string) dnsfern.DiscoverDnsCertsConfig {
 }
 
 // getDiscoverDNSRecordsConfig creates and returns a configuration for DNS records discovery
-func getDiscoverDNSRecordsConfig(domain string, recordTypes []common.DnsRecordType) dnsfern.DiscoverDnsRecordsConfig {
+func getDiscoverDNSRecordsConfig(domain string, recordTypes []string) dnsfern.DiscoverDnsRecordsConfig {
 	return dnsfern.DiscoverDnsRecordsConfig{
 		Domain:      domain,
 		RecordTypes: recordTypes,

--- a/fern/definition/discover/dns/records.yml
+++ b/fern/definition/discover/dns/records.yml
@@ -1,11 +1,10 @@
 imports:
   dns: ../../common/dns.yml
-
 types:
   DiscoverDnsRecordsConfig:
     properties:
       domain: string
-      recordTypes: list<dns.DnsRecordType>
+      recordTypes: list<string>
   DiscoverDnsRecordsResult:
     properties:
       dnsRecords: optional<list<dns.DnsRecord>>

--- a/internal/discover/dns/records.go
+++ b/internal/discover/dns/records.go
@@ -162,7 +162,12 @@ func DiscoverDomainDNSRecords(ctx context.Context, config dnsfern.DiscoverDnsRec
 		recordTypeEnum, err := common.NewDnsRecordTypeFromString(recordType)
 		// SHould never happen since we early exit in cmd file
 		if err != nil {
+			log.Error("Invalid DNS record type",
+				svc1log.SafeParam("domain", config.Domain),
+				svc1log.SafeParam("record_type", recordType),
+				svc1log.SafeParam("error", err.Error()))
 			errors = append(errors, err.Error())
+			continue
 		}
 		recordTypes = append(recordTypes, recordTypeEnum)
 	}

--- a/internal/discover/dns/records.go
+++ b/internal/discover/dns/records.go
@@ -157,8 +157,18 @@ func DiscoverDomainDNSRecords(ctx context.Context, config dnsfern.DiscoverDnsRec
 		errors = append(errors, err.Error())
 	}
 
+	recordTypes := []common.DnsRecordType{}
+	for _, recordType := range config.RecordTypes {
+		recordTypeEnum, err := common.NewDnsRecordTypeFromString(recordType)
+		// SHould never happen since we early exit in cmd file
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+		recordTypes = append(recordTypes, recordTypeEnum)
+	}
+
 	// Filter DNS records based on requested types
-	dnsRecords := filterDNSRecordsByType(allDNSRecords, config.RecordTypes)
+	dnsRecords := filterDNSRecordsByType(allDNSRecords, recordTypes)
 	log.Debug("Filtered DNS records",
 		svc1log.SafeParam("domain", config.Domain),
 		svc1log.SafeParam("total_records", len(allDNSRecords)),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> This changes a generated API/config type (`recordTypes`) and could break callers or downstream code expecting the enum list, though runtime behavior is largely preserved via validation and conversion.
> 
> **Overview**
> Updates the `DiscoverDnsRecordsConfig.recordTypes` Fern schema from `list<dns.DnsRecordType>` to `list<string>`, shifting the wire/config contract for DNS records discovery.
> 
> CLI `discover dns records` now only *validates* `--record-types` values and passes raw strings through config, while `internal/discover/dns/records.go` converts those strings back into `common.DnsRecordType` before filtering results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f12304ea5fecea60d08c91a09c6c21425d87e5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->