### PR TITLE
Add custom DNS resolver and direct AXFR targeting

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -157,8 +157,14 @@ func (a *OsintScan) InitDiscoverCommand() {
 				}
 			}
 
+			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
 			// Create config
-			config := getDiscoverDNSRecordsConfig(domain, recordTypes)
+			config := getDiscoverDNSRecordsConfig(domain, recordTypes, dnsResolvers)
 
 			// Create report
 			report := dns.DiscoverDomainDNSRecords(cmd.Context(), config)
@@ -169,6 +175,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSRecordsCmd.Flags().String("domain", "", "The domain name to query for DNS records")
 	discoverDNSRecordsCmd.Flags().StringSlice("record-types", []string{"ALL"}, "Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, ALL)")
+	discoverDNSRecordsCmd.Flags().StringSlice("dns-resolvers", []string{}, "DNS resolvers to use for record lookups (e.g. 10.0.0.1:53). Uses public resolvers if not set.")
 
 	// Mark Required Flags
 	_ = discoverDNSRecordsCmd.MarkFlagRequired("domain")
@@ -779,10 +786,11 @@ func getDiscoverDNSCertsConfig(domain string) dnsfern.DiscoverDnsCertsConfig {
 }
 
 // getDiscoverDNSRecordsConfig creates and returns a configuration for DNS records discovery
-func getDiscoverDNSRecordsConfig(domain string, recordTypes []string) dnsfern.DiscoverDnsRecordsConfig {
+func getDiscoverDNSRecordsConfig(domain string, recordTypes []string, dnsResolvers []string) dnsfern.DiscoverDnsRecordsConfig {
 	return dnsfern.DiscoverDnsRecordsConfig{
-		Domain:      domain,
-		RecordTypes: recordTypes,
+		Domain:       domain,
+		RecordTypes:  recordTypes,
+		DnsResolvers: dnsResolvers,
 	}
 }
 

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -54,7 +54,20 @@ func (a *OsintScan) InitEnumerateCommand() {
 				}
 			}
 
-			config := getEnumerateDNSZoneTransferConfig(zones, dnsResolvers, timeout)
+			targetNameservers, err := cmd.Flags().GetStringSlice("target-nameservers")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+
+			for _, ns := range targetNameservers {
+				if err = utils.ValidateDNSServerAddress(ns); err != nil {
+					a.OutputSignal.AddError(fmt.Errorf("invalid target nameserver %s: %w", ns, err))
+					return
+				}
+			}
+
+			config := getEnumerateDNSZoneTransferConfig(zones, dnsResolvers, targetNameservers, timeout)
 
 			report, err := zonetransfer.TestZoneTransfer(cmd.Context(), config)
 			if err != nil {
@@ -71,6 +84,7 @@ func (a *OsintScan) InitEnumerateCommand() {
 	// Config Flags
 	enumerateDNSZoneTransferCmd.Flags().Int("timeout", 30, "Timeout in seconds for each zone transfer request")
 	enumerateDNSZoneTransferCmd.Flags().StringSlice("dns-resolvers", []string{"1.1.1.1:53"}, "DNS resolvers to use for NS lookups and hostname resolution (e.g. 1.1.1.1:53)")
+	enumerateDNSZoneTransferCmd.Flags().StringSlice("target-nameservers", []string{}, "Nameserver IPs to attempt AXFR against directly, bypassing NS record lookup (e.g. 10.0.0.1:53)")
 
 	_ = enumerateDNSZoneTransferCmd.MarkFlagRequired("zones")
 
@@ -80,10 +94,11 @@ func (a *OsintScan) InitEnumerateCommand() {
 }
 
 // getEnumerateDNSZoneTransferConfig creates and returns a configuration for DNS zone transfer enumeration
-func getEnumerateDNSZoneTransferConfig(zones []string, dnsResolvers []string, timeout int) dnsfern.EnumerateDnsZoneTransferConfig {
+func getEnumerateDNSZoneTransferConfig(zones []string, dnsResolvers []string, targetNameservers []string, timeout int) dnsfern.EnumerateDnsZoneTransferConfig {
 	return dnsfern.EnumerateDnsZoneTransferConfig{
-		Zones:        zones,
-		DnsResolvers: dnsResolvers,
-		Timeout:      timeout,
+		Zones:             zones,
+		DnsResolvers:      dnsResolvers,
+		TargetNameservers: targetNameservers,
+		Timeout:           timeout,
 	}
 }

--- a/fern/definition/discover/dns/records.yml
+++ b/fern/definition/discover/dns/records.yml
@@ -5,6 +5,7 @@ types:
     properties:
       domain: string
       recordTypes: list<string>
+      dnsResolvers: optional<list<string>>
   DiscoverDnsRecordsResult:
     properties:
       dnsRecords: optional<list<dns.DnsRecord>>

--- a/fern/definition/enumerate/dns/zonetransfer.yml
+++ b/fern/definition/enumerate/dns/zonetransfer.yml
@@ -6,6 +6,7 @@ types:
     properties:
       zones: list<string>
       dnsResolvers: list<string>
+      targetNameservers: optional<list<string>>
       timeout: integer
 # Report Structs
   DnsZoneTransferApplication:

--- a/internal/discover/dns/records.go
+++ b/internal/discover/dns/records.go
@@ -3,7 +3,9 @@ package dns
 import (
 	"context"
 	"fmt"
+	"net"
 	"slices"
+	"strings"
 
 	common "github.com/Method-Security/osintscan/generated/go/common"
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
@@ -11,6 +13,27 @@ import (
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 	"github.com/projectdiscovery/dnsx/libs/dnsx"
 )
+
+// normalizeDnsxResolvers converts resolver addresses (e.g. "1.1.1.1:53") to the
+// format expected by the dnsx library ("udp:1.1.1.1:53").
+func normalizeDnsxResolvers(resolvers []string) []string {
+	if len(resolvers) == 0 {
+		return nil
+	}
+	normalized := make([]string, 0, len(resolvers))
+	for _, r := range resolvers {
+		if strings.HasPrefix(r, "udp:") || strings.HasPrefix(r, "tcp:") {
+			normalized = append(normalized, r)
+			continue
+		}
+		// Add default port if missing
+		if _, _, err := net.SplitHostPort(r); err != nil {
+			r = net.JoinHostPort(r, "53")
+		}
+		normalized = append(normalized, "udp:"+r)
+	}
+	return normalized
+}
 
 // filterDNSRecordsByType filters DNS records based on the requested record types
 func filterDNSRecordsByType(records []*common.DnsRecord, recordTypes []common.DnsRecordType) []*common.DnsRecord {
@@ -44,7 +67,7 @@ func filterDNSRecordsByType(records []*common.DnsRecord, recordTypes []common.Dn
 }
 
 // getDNSRecords queries DNS for the specified record types for a domain and returns a DnsRecords struct.
-func getDNSRecords(ctx context.Context, domain string, questionTypes []uint16) ([]*common.DnsRecord, error) {
+func getDNSRecords(ctx context.Context, domain string, questionTypes []uint16, dnsResolvers []string) ([]*common.DnsRecord, error) {
 	log := svc1log.FromContext(ctx)
 
 	log.Debug("Querying DNS records",
@@ -53,6 +76,9 @@ func getDNSRecords(ctx context.Context, domain string, questionTypes []uint16) (
 
 	options := dnsx.DefaultOptions
 	options.QuestionTypes = questionTypes
+	if len(dnsResolvers) > 0 {
+		options.BaseResolvers = dnsResolvers
+	}
 	client, err := dnsx.New(options)
 	if err != nil {
 		log.Warn("Failed to create DNS client",
@@ -147,9 +173,12 @@ func DiscoverDomainDNSRecords(ctx context.Context, config dnsfern.DiscoverDnsRec
 		svc1log.SafeParam("domain", config.Domain),
 		svc1log.SafeParam("requested_record_types", len(config.RecordTypes)))
 
+	// Normalize resolver format for dnsx (requires "udp:host:port" prefix)
+	resolvers := normalizeDnsxResolvers(config.DnsResolvers)
+
 	// Get all the DNS records (query all types, then filter)
 	questionTypes := []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeCAA, dns.TypeCNAME, dns.TypeMX, dns.TypeNS, dns.TypePTR, dns.TypeSOA, dns.TypeSRV, dns.TypeTXT}
-	allDNSRecords, err := getDNSRecords(ctx, config.Domain, questionTypes)
+	allDNSRecords, err := getDNSRecords(ctx, config.Domain, questionTypes, resolvers)
 	if err != nil {
 		log.Warn("Failed to get DNS records",
 			svc1log.SafeParam("domain", config.Domain),
@@ -195,7 +224,7 @@ func DiscoverDomainDNSRecords(ctx context.Context, config dnsfern.DiscoverDnsRec
 		dmarcDomain := "_dmarc." + config.Domain
 		log.Debug("Querying DMARC records", svc1log.SafeParam("dmarc_domain", dmarcDomain))
 		var dmarcErr error
-		dmarcRecords, dmarcErr = getDNSRecords(ctx, dmarcDomain, []uint16{dns.TypeTXT})
+		dmarcRecords, dmarcErr = getDNSRecords(ctx, dmarcDomain, []uint16{dns.TypeTXT}, resolvers)
 		if dmarcErr != nil {
 			log.Warn("Failed to get DMARC records",
 				svc1log.SafeParam("dmarc_domain", dmarcDomain),
@@ -219,7 +248,7 @@ func DiscoverDomainDNSRecords(ctx context.Context, config dnsfern.DiscoverDnsRec
 
 		for _, selector := range selectors {
 			dkimDomain := selector + "._domainkey." + config.Domain
-			dkimRecordForSelector, dkimErr := getDNSRecords(ctx, dkimDomain, []uint16{dns.TypeTXT})
+			dkimRecordForSelector, dkimErr := getDNSRecords(ctx, dkimDomain, []uint16{dns.TypeTXT}, resolvers)
 			if dkimErr != nil {
 				log.Debug("Failed to get DKIM records for selector",
 					svc1log.SafeParam("selector", selector),

--- a/internal/enumerate/dns/zonetransfer/zonetransfer.go
+++ b/internal/enumerate/dns/zonetransfer/zonetransfer.go
@@ -24,7 +24,12 @@ func TestZoneTransfer(ctx context.Context, config dnsfern.EnumerateDnsZoneTransf
 	}
 
 	for _, zone := range config.Zones {
-		zoneDetails := testZone(ctx, zone, config.Timeout, resolver, log, &errors)
+		var zoneDetails *dnsfern.DnsZoneTransferDetails
+		if len(config.TargetNameservers) > 0 {
+			zoneDetails = testZoneDirect(ctx, zone, config.TargetNameservers, config.Timeout, log, &errors)
+		} else {
+			zoneDetails = testZone(ctx, zone, config.Timeout, resolver, log, &errors)
+		}
 		if len(zoneDetails.Applications) > 0 {
 			details = append(details, zoneDetails)
 		}
@@ -37,6 +42,49 @@ func TestZoneTransfer(ctx context.Context, config dnsfern.EnumerateDnsZoneTransf
 		},
 		Errors: errors,
 	}, nil
+}
+
+// testZoneDirect attempts AXFR against explicitly provided nameserver IPs,
+// bypassing NS record lookup. Useful for internal DNS servers or when you know
+// the nameserver IP directly.
+func testZoneDirect(ctx context.Context, zone string, targetNameservers []string, timeout int, log svc1log.Logger, errors *[]string) *dnsfern.DnsZoneTransferDetails {
+	applications := []*dnsfern.DnsZoneTransferApplication{}
+
+	for _, ns := range targetNameservers {
+		dnsServer := ns
+		if _, _, err := net.SplitHostPort(ns); err != nil {
+			dnsServer = net.JoinHostPort(ns, "53")
+		}
+
+		log.Info("Attempting direct zone transfer",
+			svc1log.SafeParam("zone", zone),
+			svc1log.SafeParam("dnsServer", dnsServer))
+
+		records, success, errs := sendAXFRRequest(dnsServer, zone, timeout, log)
+		for _, e := range errs {
+			*errors = append(*errors, fmt.Sprintf("%s@%s: %s", zone, dnsServer, e))
+		}
+
+		if success {
+			log.Info("Zone transfer succeeded",
+				svc1log.SafeParam("zone", zone),
+				svc1log.SafeParam("dnsServer", dnsServer),
+				svc1log.SafeParam("records", len(records)))
+
+			// Use the IP as the nameserver label since we don't have a hostname
+			host, _, _ := net.SplitHostPort(dnsServer)
+			applications = append(applications, &dnsfern.DnsZoneTransferApplication{
+				Nameserver: host,
+				DnsServer:  dnsServer,
+				DnsRecords: records,
+			})
+		}
+	}
+
+	return &dnsfern.DnsZoneTransferDetails{
+		Zone:         zone,
+		Applications: applications,
+	}
 }
 
 // testZone looks up NS records for the zone, resolves each NS hostname to an IP,


### PR DESCRIPTION
## Summary
- **`discover dns records`**: Added `--dns-resolvers` flag so record lookups can use custom resolvers (e.g. internal DNS). Previously hardcoded to public resolvers via dnsx library defaults (`1.1.1.1`, `8.8.8.8`, etc).
- **`enumerate dns zone-transfer`**: Added `--target-nameservers` flag to attempt AXFR directly against specified IPs, bypassing NS record lookup. Enables zone transfer testing against internal nameservers by IP.
- Both fixes enable local/internal DNS resolution workflows that were previously broken.

## Test plan
- [x] `discover dns records --domain example.com` works with default resolvers
- [x] `discover dns records --domain example.com --dns-resolvers 8.8.8.8:53` works with custom resolver (confirmed different TTLs)
- [x] `enumerate dns zone-transfer --zones zonetransfer.me --target-nameservers 81.4.108.41:53` works with raw IP
- [x] `enumerate dns zone-transfer --zones zonetransfer.me --target-nameservers nsztm1.digi.ninja:53` works with hostname
- [x] `./godelw verify` passes (format, lint, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes DNS querying behavior by allowing caller-supplied resolvers and bypassing NS lookup for AXFR, which can alter results and failure modes in network-sensitive code paths.
> 
> **Overview**
> Adds configurable DNS infrastructure to two CLI flows.
> 
> `discover dns records` now accepts `--dns-resolvers` and plumbs it through the Fern config into record/DMARC/DKIM lookups, including normalizing resolver strings to the `dnsx`-expected `udp:host:port` format.
> 
> `enumerate dns zone-transfer` now accepts `--target-nameservers`; when provided, zone transfer testing skips NS discovery and attempts AXFR directly against the specified servers (with port defaulting), and the API schema/config is extended accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84bafaa28d4b4ccf92bf6791918133fb6cb46a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->