### PR TITLE
DNS Passive: Add Recussive Search Flag

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -520,9 +520,14 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			recursiveDepth, err := cmd.Flags().GetInt("recursive-depth")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			// Create config
-			config, err := getDiscoverDNSPassiveSubdomainConfig(domain, requestsPerSecond, threads, allSources, modules, dnsResolvers, maxDNSQueries, maxResolversQPS)
+			config, err := getDiscoverDNSPassiveSubdomainConfig(domain, requestsPerSecond, threads, allSources, modules, dnsResolvers, maxDNSQueries, maxResolversQPS, recursiveDepth)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -541,12 +546,13 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 25, "Number of concurrent threads for scanning")
 	discoverDNSSubdomainPassiveCmd.Flags().Bool("all-sources", false, "Use all passive sources (subfinder equivalent of --all)")
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("modules", []string{"SUBFINDER"}, "Which passive modules to run: SUBFINDER, AMASS, or ALL")
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("max-dns-queries", 2000, "Maximum number of DNS queries to perform per request")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("max-resolvers-qps", 100, "Maximum number of queries per second per resolver")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("recursive-depth", 0, "Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.)")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainPassiveCmd.MarkFlagRequired("domain")
@@ -799,7 +805,7 @@ func getDiscoverDNSReverseConfig(ips []string, cidr string, dnsResolvers []strin
 	config := &dnsfern.DiscoverDnsReverseConfig{
 		IpAddresses:  ips,
 		DnsResolvers: dnsResolvers,
-		Threads:      max(threads, 0),
+		Threads:      max(threads, 1),
 	}
 	if cidr != "" {
 		config.Cidr = &cidr
@@ -839,7 +845,7 @@ func getDiscoverDNSCorrelationSubdomainConfig(domains []string, threads int, tim
 }
 
 // getDiscoverDNSPassiveSubdomainConfig creates and returns a configuration for passive subdomain discovery
-func getDiscoverDNSPassiveSubdomainConfig(domain string, requestsPerSecond int, threads int, allSources bool, modules []string, dnsResolvers []string, maxDNSQueries int, maxResolversQPS int) (dnsfern.DiscoverDnsSubdomainConfig, error) {
+func getDiscoverDNSPassiveSubdomainConfig(domain string, requestsPerSecond int, threads int, allSources bool, modules []string, dnsResolvers []string, maxDNSQueries int, maxResolversQPS int, recursiveDepth int) (dnsfern.DiscoverDnsSubdomainConfig, error) {
 
 	var modulesEnum []dnsfern.DiscoverDnsSubdomainModule
 	for _, module := range modules {
@@ -855,12 +861,13 @@ func getDiscoverDNSPassiveSubdomainConfig(domain string, requestsPerSecond int, 
 		Passive: &dnsfern.DiscoverDnsSubdomainPassiveConfig{
 			Domain:            domain,
 			RequestsPerSecond: requestsPerSecond,
-			Threads:           threads,
+			Threads:           max(threads, 1),
 			AllSources:        allSources,
 			Modules:           modulesEnum,
 			DnsResolvers:      dnsResolvers,
 			MaxDnsQueries:     max(maxDNSQueries, 0),
 			MaxResolversQps:   max(maxResolversQPS, 0),
+			RecursiveDepth:    max(recursiveDepth, 0),
 		},
 	}
 	return config, nil

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -546,7 +546,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 25, "Number of concurrent threads for scanning")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning(defaults to the max which is 10)")
 	discoverDNSSubdomainPassiveCmd.Flags().Bool("all-sources", false, "Use all passive sources (subfinder equivalent of --all)")
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("modules", []string{"SUBFINDER"}, "Which passive modules to run: SUBFINDER, AMASS, or ALL")
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")

--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -546,7 +546,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning(defaults to the max which is 10)")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning (defaults to the max which is 10)")
 	discoverDNSSubdomainPassiveCmd.Flags().Bool("all-sources", false, "Use all passive sources (subfinder equivalent of --all)")
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("modules", []string{"SUBFINDER"}, "Which passive modules to run: SUBFINDER, AMASS, or ALL")
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -44,6 +44,7 @@ types:
       dnsResolvers: optional<list<string>>
       MaxDNSQueries: integer
       MaxResolversQps: integer
+      recursiveDepth: integer
 # Reports
   DiscoverDnsSubdomainConfig:
     discriminant: discoveryType

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/palantir/pkg/datetime v1.2.0
 	github.com/palantir/witchcraft-go-logging v1.61.0
 	github.com/projectdiscovery/dnsx v1.2.2
+	github.com/projectdiscovery/gologger v1.1.54
 	github.com/projectdiscovery/subfinder/v2 v2.9.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
@@ -136,7 +137,6 @@ require (
 	github.com/projectdiscovery/chaos-client v0.5.2 // indirect
 	github.com/projectdiscovery/fastdialer v0.4.1 // indirect
 	github.com/projectdiscovery/goflags v0.1.74 // indirect
-	github.com/projectdiscovery/gologger v1.1.54 // indirect
 	github.com/projectdiscovery/hmap v0.0.90 // indirect
 	github.com/projectdiscovery/machineid v0.0.0-20250715113114-c77eb3567582 // indirect
 	github.com/projectdiscovery/networkpolicy v0.1.16 // indirect

--- a/internal/discover/dns/subdomain/passive/passive.go
+++ b/internal/discover/dns/subdomain/passive/passive.go
@@ -54,9 +54,10 @@ func discoverForDomain(ctx context.Context, cfg dnsfern.DiscoverDnsSubdomainPass
 }
 
 // discoverDomainsParallel runs passive discovery across multiple domains using a
-// fixed pool of worker goroutines. Each worker creates its own subfinder runner
-// once and reuses it for every domain it processes, avoiding the overhead of
-// re-initializing provider config and passive sources per domain.
+// fixed pool of worker goroutines. The subfinder worker count is capped because
+// subfinder's passive sources are global singletons — running too many concurrent
+// enumerations causes data races on shared state and hammers external APIs into
+// rate-limiting, making things slower not faster.
 func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsfern.DiscoverDnsSubdomainPassiveConfig, runSubfinder, runAmass bool, workers int) []domainResult {
 	log := svc1log.FromContext(ctx)
 	results := make([]domainResult, len(domains))
@@ -76,6 +77,17 @@ func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsf
 		numWorkers = len(domains)
 	}
 
+	var sfRunners []*subutils.SubfinderRunner
+	if runSubfinder {
+		var err error
+		sfRunners, err = subutils.CreateSubfinderRunners(baseCfg, numWorkers)
+		if err != nil {
+			log.Warn("Failed to create subfinder runners, continuing with other modules",
+				svc1log.SafeParam("error", err.Error()))
+			sfRunners = nil
+		}
+	}
+
 	log.Info("Starting worker pool",
 		svc1log.SafeParam("workers", numWorkers),
 		svc1log.SafeParam("domains", len(domains)))
@@ -83,28 +95,12 @@ func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsf
 	var wg sync.WaitGroup
 	for w := 0; w < numWorkers; w++ {
 		wg.Add(1)
-		go func(workerID int) {
+		var sfRunner *subutils.SubfinderRunner
+		if sfRunners != nil {
+			sfRunner = sfRunners[w]
+		}
+		go func(workerID int, sfRunner *subutils.SubfinderRunner) {
 			defer wg.Done()
-
-			// Each worker creates its own subfinder runner once and reuses it
-			// for all domains it handles, instead of re-initializing per domain.
-			var sfRunner *subutils.SubfinderRunner
-			if runSubfinder {
-				r, err := subutils.NewSubfinderRunner(baseCfg)
-				if err != nil {
-					log.Warn("Worker failed to create subfinder runner",
-						svc1log.SafeParam("worker_id", workerID),
-						svc1log.SafeParam("error", err.Error()))
-					for item := range work {
-						results[item.index] = domainResult{
-							domain: item.domain,
-							errors: []string{"subfinder init failed: " + err.Error()},
-						}
-					}
-					return
-				}
-				sfRunner = r
-			}
 
 			for item := range work {
 				if ctx.Err() != nil {
@@ -142,7 +138,7 @@ func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsf
 					errors:     errors,
 				}
 			}
-		}(w)
+		}(w, sfRunner)
 	}
 
 	wg.Wait()

--- a/internal/discover/dns/subdomain/passive/passive.go
+++ b/internal/discover/dns/subdomain/passive/passive.go
@@ -53,41 +53,96 @@ func discoverForDomain(ctx context.Context, cfg dnsfern.DiscoverDnsSubdomainPass
 	return subdomains, errors
 }
 
-// discoverDomainsParallel runs passive discovery across multiple domains concurrently,
-// limited to the given number of worker goroutines. Results are collected and returned.
+// discoverDomainsParallel runs passive discovery across multiple domains using a
+// fixed pool of worker goroutines. Each worker creates its own subfinder runner
+// once and reuses it for every domain it processes, avoiding the overhead of
+// re-initializing provider config and passive sources per domain.
 func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsfern.DiscoverDnsSubdomainPassiveConfig, runSubfinder, runAmass bool, workers int) []domainResult {
+	log := svc1log.FromContext(ctx)
 	results := make([]domainResult, len(domains))
-	sem := make(chan struct{}, workers)
-	var wg sync.WaitGroup
 
-	for i, domain := range domains {
+	type workItem struct {
+		index  int
+		domain string
+	}
+	work := make(chan workItem, len(domains))
+	for i, d := range domains {
+		work <- workItem{index: i, domain: d}
+	}
+	close(work)
+
+	numWorkers := workers
+	if numWorkers > len(domains) {
+		numWorkers = len(domains)
+	}
+
+	log.Info("Starting worker pool",
+		svc1log.SafeParam("workers", numWorkers),
+		svc1log.SafeParam("domains", len(domains)))
+
+	var wg sync.WaitGroup
+	for w := 0; w < numWorkers; w++ {
 		wg.Add(1)
-		go func(idx int, d string) {
+		go func(workerID int) {
 			defer wg.Done()
 
-			// Acquire semaphore slot
-			sem <- struct{}{}
-			defer func() { <-sem }()
-
-			// Check for context cancellation before starting work
-			if ctx.Err() != nil {
-				results[idx] = domainResult{
-					domain: d,
-					errors: []string{ctx.Err().Error()},
+			// Each worker creates its own subfinder runner once and reuses it
+			// for all domains it handles, instead of re-initializing per domain.
+			var sfRunner *subutils.SubfinderRunner
+			if runSubfinder {
+				r, err := subutils.NewSubfinderRunner(baseCfg)
+				if err != nil {
+					log.Warn("Worker failed to create subfinder runner",
+						svc1log.SafeParam("worker_id", workerID),
+						svc1log.SafeParam("error", err.Error()))
+					for item := range work {
+						results[item.index] = domainResult{
+							domain: item.domain,
+							errors: []string{"subfinder init failed: " + err.Error()},
+						}
+					}
+					return
 				}
-				return
+				sfRunner = r
 			}
 
-			cfg := baseCfg
-			cfg.Domain = d
+			for item := range work {
+				if ctx.Err() != nil {
+					results[item.index] = domainResult{
+						domain: item.domain,
+						errors: []string{ctx.Err().Error()},
+					}
+					continue
+				}
 
-			subs, errs := discoverForDomain(ctx, cfg, runSubfinder, runAmass)
-			results[idx] = domainResult{
-				domain:     d,
-				subdomains: subs,
-				errors:     errs,
+				var subdomains []string
+				var errors []string
+
+				if sfRunner != nil {
+					subs, err := sfRunner.EnumerateDomain(ctx, item.domain)
+					if err != nil {
+						errors = append(errors, err.Error())
+					}
+					subdomains = append(subdomains, subs...)
+				}
+
+				if runAmass {
+					cfg := baseCfg
+					cfg.Domain = item.domain
+					subs, err := subutils.GetSubdomainsPassiveWithAmass(ctx, cfg)
+					if err != nil {
+						errors = append(errors, err.Error())
+					}
+					subdomains = append(subdomains, subs...)
+				}
+
+				results[item.index] = domainResult{
+					domain:     item.domain,
+					subdomains: subdomains,
+					errors:     errors,
+				}
 			}
-		}(i, domain)
+		}(w)
 	}
 
 	wg.Wait()

--- a/internal/discover/dns/subdomain/passive/passive.go
+++ b/internal/discover/dns/subdomain/passive/passive.go
@@ -151,17 +151,6 @@ func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsf
 // extractChildDomains returns the unique set of domains that are exactly one
 // label deeper than rootDomain, derived from the discovered subdomains.
 //
-// For example, with rootDomain "kpmg.com" and depth 1:
-//
-//	a.us.kpmg.com    → us.kpmg.com
-//	b.us.kpmg.com    → us.kpmg.com  (deduped)
-//	c.ema.kpmg.com   → ema.kpmg.com
-//	x.y.dev.kpmg.com → dev.kpmg.com
-//
-// At depth 2, the same logic extracts two-label-deep children:
-//
-//	x.east.us.kpmg.com → east.us.kpmg.com
-//
 // This dramatically reduces the recursive scan surface compared to rescanning
 // every individual FQDN.
 func extractChildDomains(subdomains []string, rootDomain string, depth int, scanned map[string]bool) []string {

--- a/internal/discover/dns/subdomain/passive/passive.go
+++ b/internal/discover/dns/subdomain/passive/passive.go
@@ -76,6 +76,9 @@ func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsf
 	if numWorkers > len(domains) {
 		numWorkers = len(domains)
 	}
+	if runSubfinder && numWorkers > subutils.MaxConcurrentSubfinderEnumerations {
+		numWorkers = subutils.MaxConcurrentSubfinderEnumerations
+	}
 
 	var sfRunners []*subutils.SubfinderRunner
 	if runSubfinder {
@@ -145,19 +148,42 @@ func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsf
 	return results
 }
 
-// extractUniqueDomains returns all unique domain values from the subdomain list
-// that have not already been scanned.
-func extractUniqueDomains(subdomains []string, scanned map[string]bool) []string {
+// extractChildDomains returns the unique set of domains that are exactly one
+// label deeper than rootDomain, derived from the discovered subdomains.
+//
+// For example, with rootDomain "kpmg.com" and depth 1:
+//
+//	a.us.kpmg.com    → us.kpmg.com
+//	b.us.kpmg.com    → us.kpmg.com  (deduped)
+//	c.ema.kpmg.com   → ema.kpmg.com
+//	x.y.dev.kpmg.com → dev.kpmg.com
+//
+// At depth 2, the same logic extracts two-label-deep children:
+//
+//	x.east.us.kpmg.com → east.us.kpmg.com
+//
+// This dramatically reduces the recursive scan surface compared to rescanning
+// every individual FQDN.
+func extractChildDomains(subdomains []string, rootDomain string, depth int, scanned map[string]bool) []string {
+	rootLabels := strings.Count(rootDomain, ".") + 1
+	targetLabels := rootLabels + depth
+
 	unique := map[string]bool{}
 	for _, sub := range subdomains {
 		sub = strings.TrimSuffix(strings.TrimSpace(sub), ".")
 		if sub == "" {
 			continue
 		}
-		if !scanned[sub] && !unique[sub] {
-			unique[sub] = true
+		labels := strings.Split(sub, ".")
+		if len(labels) <= rootLabels || len(labels) < targetLabels {
+			continue
+		}
+		child := strings.Join(labels[len(labels)-targetLabels:], ".")
+		if child != rootDomain && !scanned[child] && !unique[child] {
+			unique[child] = true
 		}
 	}
+
 	result := make([]string, 0, len(unique))
 	for d := range unique {
 		result = append(result, d)
@@ -202,12 +228,11 @@ func GetDomainSubdomainsPassive(ctx context.Context, config dnsfern.DiscoverDnsS
 	workers := config.Passive.Threads
 
 	for depth := 1; depth <= recursiveDepth; depth++ {
-		// Get domains we haven't scanned yet from all discovered subdomains
 		allSubs := make([]string, 0, len(allSubdomainsSet))
 		for s := range allSubdomainsSet {
 			allSubs = append(allSubs, s)
 		}
-		newDomains := extractUniqueDomains(allSubs, scannedDomains)
+		newDomains := extractChildDomains(allSubs, config.Passive.Domain, depth, scannedDomains)
 
 		if len(newDomains) == 0 {
 			log.Info("No new domains to scan, stopping recursion early",

--- a/internal/discover/dns/subdomain/passive/passive.go
+++ b/internal/discover/dns/subdomain/passive/passive.go
@@ -3,50 +3,207 @@ package subdomain
 import (
 	"context"
 	"slices"
+	"sort"
+	"strings"
+	"sync"
 
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
 	subutils "github.com/Method-Security/osintscan/internal/discover/dns/subdomain/passive/utils"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
+// domainResult holds the output of a single domain discovery goroutine.
+type domainResult struct {
+	domain     string
+	subdomains []string
+	errors     []string
+}
+
 // shouldRunModule checks if a specific module should run based on the selected modules list.
 func shouldRunModule(selectedModules []dnsfern.DiscoverDnsSubdomainModule, module dnsfern.DiscoverDnsSubdomainModule) bool {
 	return slices.Contains(selectedModules, module) || slices.Contains(selectedModules, dnsfern.DiscoverDnsSubdomainModuleAll)
 }
 
+// discoverForDomain runs passive discovery (subfinder and/or amass) for a single domain
+// and returns the discovered subdomains and any error strings.
+func discoverForDomain(ctx context.Context, cfg dnsfern.DiscoverDnsSubdomainPassiveConfig, runSubfinder, runAmass bool) ([]string, []string) {
+	log := svc1log.FromContext(ctx)
+	var subdomains []string
+	var errors []string
+
+	if runSubfinder {
+		subs, err := subutils.GetSubdomainsPassiveWithSubfinder(ctx, cfg)
+		if err != nil {
+			errors = append(errors, err.Error())
+		}
+		subdomains = append(subdomains, subs...)
+	}
+
+	if runAmass {
+		subs, err := subutils.GetSubdomainsPassiveWithAmass(ctx, cfg)
+		if err != nil {
+			log.Warn("Passive subdomain discovery (amass v4) encountered errors",
+				svc1log.SafeParam("domain", cfg.Domain),
+				svc1log.SafeParam("error", err.Error()))
+			errors = append(errors, err.Error())
+		}
+		subdomains = append(subdomains, subs...)
+	}
+
+	return subdomains, errors
+}
+
+// discoverDomainsParallel runs passive discovery across multiple domains concurrently,
+// limited to the given number of worker goroutines. Results are collected and returned.
+func discoverDomainsParallel(ctx context.Context, domains []string, baseCfg dnsfern.DiscoverDnsSubdomainPassiveConfig, runSubfinder, runAmass bool, workers int) []domainResult {
+	results := make([]domainResult, len(domains))
+	sem := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+
+	for i, domain := range domains {
+		wg.Add(1)
+		go func(idx int, d string) {
+			defer wg.Done()
+
+			// Acquire semaphore slot
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			// Check for context cancellation before starting work
+			if ctx.Err() != nil {
+				results[idx] = domainResult{
+					domain: d,
+					errors: []string{ctx.Err().Error()},
+				}
+				return
+			}
+
+			cfg := baseCfg
+			cfg.Domain = d
+
+			subs, errs := discoverForDomain(ctx, cfg, runSubfinder, runAmass)
+			results[idx] = domainResult{
+				domain:     d,
+				subdomains: subs,
+				errors:     errs,
+			}
+		}(i, domain)
+	}
+
+	wg.Wait()
+	return results
+}
+
+// extractUniqueDomains returns all unique domain values from the subdomain list
+// that have not already been scanned.
+func extractUniqueDomains(subdomains []string, scanned map[string]bool) []string {
+	unique := map[string]bool{}
+	for _, sub := range subdomains {
+		sub = strings.TrimSuffix(strings.TrimSpace(sub), ".")
+		if sub == "" {
+			continue
+		}
+		if !scanned[sub] && !unique[sub] {
+			unique[sub] = true
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for d := range unique {
+		result = append(result, d)
+	}
+	sort.Strings(result)
+	return result
+}
+
 // GetDomainSubdomainsPassive queries passive sources (subfinder and/or amass v4) for subdomains of a given domain.
+// When recursiveDepth > 0, discovered subdomains are fed back into the discovery process
+// for additional rounds, avoiding rescanning domains that have already been processed.
+// Recursive rounds are parallelized using the configured thread count.
 // Returns a report containing all discovered subdomains and any errors encountered.
 func GetDomainSubdomainsPassive(ctx context.Context, config dnsfern.DiscoverDnsSubdomainConfig) (dnsfern.DiscoverDnsSubdomainReport, error) {
 	log := svc1log.FromContext(ctx)
 	errors := []string{}
 
 	log.Info("Starting passive subdomain discovery",
-		svc1log.SafeParam("domain", config.Passive.Domain))
+		svc1log.SafeParam("domain", config.Passive.Domain),
+		svc1log.SafeParam("recursive_depth", config.Passive.RecursiveDepth))
 
-	// Determine module selection from config (defaults to "subfinder" if not provided)
 	selectedModules := config.Passive.Modules
 	runSubfinder := shouldRunModule(selectedModules, dnsfern.DiscoverDnsSubdomainModuleSubfinder)
 	runAmass := shouldRunModule(selectedModules, dnsfern.DiscoverDnsSubdomainModuleAmass)
 
-	allSubdomains := []string{}
-	if runSubfinder {
-		subfinderSubdomains, err := subutils.GetSubdomainsPassiveWithSubfinder(ctx, *config.Passive)
-		if err != nil {
-			errors = append(errors, err.Error())
-		}
-		allSubdomains = append(allSubdomains, subfinderSubdomains...)
+	// Track all discovered subdomains and which domains we've already scanned
+	allSubdomainsSet := map[string]bool{}
+	scannedDomains := map[string]bool{}
+
+	// Initial scan of the primary domain
+	initialCfg := *config.Passive
+	subs, errs := discoverForDomain(ctx, initialCfg, runSubfinder, runAmass)
+	errors = append(errors, errs...)
+	scannedDomains[config.Passive.Domain] = true
+
+	for _, s := range subs {
+		allSubdomainsSet[s] = true
 	}
 
-	if runAmass {
-		amassSubdomains, amassErr := subutils.GetSubdomainsPassiveWithAmass(ctx, *config.Passive)
-		if amassErr != nil {
-			log.Warn("Passive subdomain discovery (amass v4) encountered errors",
-				svc1log.SafeParam("domain", config.Passive.Domain),
-				svc1log.SafeParam("error", amassErr.Error()))
-			errors = append(errors, amassErr.Error())
+	// Recursive rounds (parallelized)
+	recursiveDepth := config.Passive.RecursiveDepth
+	workers := config.Passive.Threads
+
+	for depth := 1; depth <= recursiveDepth; depth++ {
+		// Get domains we haven't scanned yet from all discovered subdomains
+		allSubs := make([]string, 0, len(allSubdomainsSet))
+		for s := range allSubdomainsSet {
+			allSubs = append(allSubs, s)
 		}
-		allSubdomains = append(allSubdomains, amassSubdomains...)
+		newDomains := extractUniqueDomains(allSubs, scannedDomains)
+
+		if len(newDomains) == 0 {
+			log.Info("No new domains to scan, stopping recursion early",
+				svc1log.SafeParam("depth", depth))
+			break
+		}
+
+		log.Info("Starting recursive discovery pass",
+			svc1log.SafeParam("depth", depth),
+			svc1log.SafeParam("max_depth", recursiveDepth),
+			svc1log.SafeParam("domains_to_scan", len(newDomains)),
+			svc1log.SafeParam("workers", workers))
+
+		// Mark all domains as scanned before launching workers to prevent
+		// duplicate work if the same domain appears in multiple rounds.
+		for _, domain := range newDomains {
+			scannedDomains[domain] = true
+		}
+
+		// Run discovery for all new domains concurrently
+		results := discoverDomainsParallel(ctx, newDomains, *config.Passive, runSubfinder, runAmass, workers)
+
+		// Collect results
+		for _, r := range results {
+			errors = append(errors, r.errors...)
+
+			newFound := 0
+			for _, s := range r.subdomains {
+				if !allSubdomainsSet[s] {
+					allSubdomainsSet[s] = true
+					newFound++
+				}
+			}
+
+			log.Debug("Recursive discovery for domain completed",
+				svc1log.SafeParam("domain", r.domain),
+				svc1log.SafeParam("depth", depth),
+				svc1log.SafeParam("new_subdomains", newFound))
+		}
 	}
+
+	// Convert set to sorted slice
+	allSubdomains := make([]string, 0, len(allSubdomainsSet))
+	for s := range allSubdomainsSet {
+		allSubdomains = append(allSubdomains, s)
+	}
+	sort.Strings(allSubdomains)
 
 	result := dnsfern.DiscoverDnsSubdomainResult{
 		Subdomains: allSubdomains,
@@ -61,6 +218,8 @@ func GetDomainSubdomainsPassive(ctx context.Context, config dnsfern.DiscoverDnsS
 	log.Info("Completed passive subdomain discovery",
 		svc1log.SafeParam("domain", config.Passive.Domain),
 		svc1log.SafeParam("subdomains_found", len(allSubdomains)),
+		svc1log.SafeParam("domains_scanned", len(scannedDomains)),
+		svc1log.SafeParam("recursive_depth", recursiveDepth),
 		svc1log.SafeParam("error_count", len(errors)))
 
 	return report, nil

--- a/internal/discover/dns/subdomain/passive/utils/subfinder.go
+++ b/internal/discover/dns/subdomain/passive/utils/subfinder.go
@@ -11,7 +11,61 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/runner"
 )
 
-// GetSubdomainsPassiveWithSubfinder runs subfinder in passive mode for a single domain and returns discovered subdomains.
+// SubfinderRunner wraps a pre-initialized subfinder runner for reuse across
+// multiple domain enumerations, avoiding repeated initialization overhead.
+type SubfinderRunner struct {
+	runner *runner.Runner
+}
+
+// NewSubfinderRunner creates a reusable SubfinderRunner from the given config.
+// The returned runner can enumerate many domains without re-loading provider
+// config or re-initializing passive sources each time.
+func NewSubfinderRunner(cfg dnsfern.DiscoverDnsSubdomainPassiveConfig) (*SubfinderRunner, error) {
+	opts := &runner.Options{
+		All:                cfg.AllSources,
+		Threads:            cfg.Threads,
+		Timeout:            30,
+		MaxEnumerationTime: 10,
+		RateLimit:          cfg.RequestsPerSecond,
+	}
+	r, err := runner.NewRunner(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &SubfinderRunner{runner: r}, nil
+}
+
+// EnumerateDomain runs passive subdomain enumeration for a single domain
+// using the pre-initialized runner.
+func (s *SubfinderRunner) EnumerateDomain(ctx context.Context, domain string) ([]string, error) {
+	log := svc1log.FromContext(ctx)
+
+	log.Debug("Starting subfinder enumeration", svc1log.SafeParam("domain", domain))
+
+	output := &bytes.Buffer{}
+	results, err := s.runner.EnumerateSingleDomainWithCtx(ctx, domain, []io.Writer{output})
+	if err != nil {
+		log.Warn("Subfinder enumeration failed",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("error", err.Error()))
+		return []string{}, err
+	}
+
+	subdomains := make([]string, 0, len(results))
+	for sub := range results {
+		subdomains = append(subdomains, sub)
+	}
+	sort.Strings(subdomains)
+
+	log.Debug("Subfinder enumeration completed",
+		svc1log.SafeParam("domain", domain),
+		svc1log.SafeParam("subdomains_found", len(subdomains)))
+
+	return subdomains, nil
+}
+
+// GetSubdomainsPassiveWithSubfinder runs subfinder in passive mode for a single domain.
+// For batch operations, prefer NewSubfinderRunner + EnumerateDomain to avoid repeated initialization.
 func GetSubdomainsPassiveWithSubfinder(ctx context.Context, cfg dnsfern.DiscoverDnsSubdomainPassiveConfig) ([]string, error) {
 	log := svc1log.FromContext(ctx)
 
@@ -22,17 +76,7 @@ func GetSubdomainsPassiveWithSubfinder(ctx context.Context, cfg dnsfern.Discover
 		svc1log.SafeParam("all_sources", cfg.AllSources),
 	)
 
-	// Set subfinder config
-	subfinderOpts := &runner.Options{
-		All:                cfg.AllSources,
-		Threads:            cfg.Threads,
-		Timeout:            30,
-		MaxEnumerationTime: 10,
-		RateLimit:          cfg.RequestsPerSecond,
-	}
-
-	// Initialize subfinder runner
-	subfinder, err := runner.NewRunner(subfinderOpts)
+	sr, err := NewSubfinderRunner(cfg)
 	if err != nil {
 		log.Warn("Failed to initialize subfinder runner",
 			svc1log.SafeParam("domain", cfg.Domain),
@@ -40,30 +84,5 @@ func GetSubdomainsPassiveWithSubfinder(ctx context.Context, cfg dnsfern.Discover
 		return []string{}, err
 	}
 
-	log.Debug("Starting subfinder enumeration", svc1log.SafeParam("domain", cfg.Domain))
-
-	output := &bytes.Buffer{}
-	// Run subdomain enumeration for the given domain
-	results, err := subfinder.EnumerateSingleDomainWithCtx(ctx, cfg.Domain, []io.Writer{output})
-	if err != nil {
-		log.Warn("Subfinder enumeration failed",
-			svc1log.SafeParam("domain", cfg.Domain),
-			svc1log.SafeParam("error", err.Error()))
-		return []string{}, err
-	}
-
-	// Collect subdomains from results map keys
-	subdomains := make([]string, 0, len(results))
-	for sub := range results {
-		subdomains = append(subdomains, sub)
-	}
-
-	// Sort subdomains for deterministic output
-	sort.Strings(subdomains)
-
-	log.Debug("Subfinder enumeration completed",
-		svc1log.SafeParam("domain", cfg.Domain),
-		svc1log.SafeParam("subdomains_found", len(subdomains)))
-
-	return subdomains, nil
+	return sr.EnumerateDomain(ctx, cfg.Domain)
 }

--- a/internal/discover/dns/subdomain/passive/utils/subfinder.go
+++ b/internal/discover/dns/subdomain/passive/utils/subfinder.go
@@ -8,6 +8,8 @@ import (
 
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/gologger/levels"
 	"github.com/projectdiscovery/subfinder/v2/pkg/runner"
 )
 
@@ -17,22 +19,48 @@ type SubfinderRunner struct {
 	runner *runner.Runner
 }
 
-// NewSubfinderRunner creates a reusable SubfinderRunner from the given config.
-// The returned runner can enumerate many domains without re-loading provider
-// config or re-initializing passive sources each time.
-func NewSubfinderRunner(cfg dnsfern.DiscoverDnsSubdomainPassiveConfig) (*SubfinderRunner, error) {
-	opts := &runner.Options{
+func newSubfinderOpts(cfg dnsfern.DiscoverDnsSubdomainPassiveConfig) *runner.Options {
+	return &runner.Options{
 		All:                cfg.AllSources,
 		Threads:            cfg.Threads,
 		Timeout:            30,
 		MaxEnumerationTime: 10,
 		RateLimit:          cfg.RequestsPerSecond,
 	}
-	r, err := runner.NewRunner(opts)
+}
+
+// NewSubfinderRunner creates a single reusable SubfinderRunner.
+// For batch creation (worker pools), prefer CreateSubfinderRunners to avoid
+// redundant provider config loading.
+func NewSubfinderRunner(cfg dnsfern.DiscoverDnsSubdomainPassiveConfig) (*SubfinderRunner, error) {
+	r, err := runner.NewRunner(newSubfinderOpts(cfg))
 	if err != nil {
 		return nil, err
 	}
 	return &SubfinderRunner{runner: r}, nil
+}
+
+// CreateSubfinderRunners creates count independent runners for use in a worker
+// pool. Runners use tighter timeouts suited for recursive scanning where most
+// domains return no results. The provider config is loaded once by the first
+// runner; subsequent runners suppress the redundant log message.
+func CreateSubfinderRunners(cfg dnsfern.DiscoverDnsSubdomainPassiveConfig, count int) ([]*SubfinderRunner, error) {
+	runners := make([]*SubfinderRunner, count)
+	for i := 0; i < count; i++ {
+		if i == 1 {
+			// gologger levels: Fatal(0) < Silent(1) < Error(2) < Info(3) < Warning(4)
+			// Setting to Error suppresses the redundant "Loading provider config" Info log.
+			gologger.DefaultLogger.SetMaxLevel(levels.LevelError)
+		}
+		r, err := runner.NewRunner(newSubfinderOpts(cfg))
+		if err != nil {
+			gologger.DefaultLogger.SetMaxLevel(levels.LevelInfo)
+			return nil, err
+		}
+		runners[i] = &SubfinderRunner{runner: r}
+	}
+	gologger.DefaultLogger.SetMaxLevel(levels.LevelInfo)
+	return runners, nil
 }
 
 // EnumerateDomain runs passive subdomain enumeration for a single domain
@@ -65,7 +93,7 @@ func (s *SubfinderRunner) EnumerateDomain(ctx context.Context, domain string) ([
 }
 
 // GetSubdomainsPassiveWithSubfinder runs subfinder in passive mode for a single domain.
-// For batch operations, prefer NewSubfinderRunner + EnumerateDomain to avoid repeated initialization.
+// For batch operations, prefer CreateSubfinderRunners + EnumerateDomain to avoid repeated initialization.
 func GetSubdomainsPassiveWithSubfinder(ctx context.Context, cfg dnsfern.DiscoverDnsSubdomainPassiveConfig) ([]string, error) {
 	log := svc1log.FromContext(ctx)
 

--- a/internal/discover/dns/subdomain/passive/utils/subfinder.go
+++ b/internal/discover/dns/subdomain/passive/utils/subfinder.go
@@ -13,6 +13,12 @@ import (
 	"github.com/projectdiscovery/subfinder/v2/pkg/runner"
 )
 
+// MaxConcurrentSubfinderEnumerations limits parallel subfinder runs during
+// recursive scanning. Subfinder's passive sources are global singletons and
+// external APIs (crt.sh, hackertarget, etc.) aggressively rate-limit or drop
+// connections under high concurrency, causing 0-result responses.
+const MaxConcurrentSubfinderEnumerations = 10
+
 // SubfinderRunner wraps a pre-initialized subfinder runner for reuse across
 // multiple domain enumerations, avoiding repeated initialization overhead.
 type SubfinderRunner struct {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds recursive, parallelized passive subdomain discovery and changes concurrency behavior (thread minimums, worker pools, capped subfinder parallelism), which can affect runtime, external rate-limits, and result completeness.
> 
> **Overview**
> Adds an optional **recursive passive subdomain discovery** mode driven by a new `--recursive-depth` flag and corresponding `recursiveDepth` config/schema field.
> 
> Refactors passive enumeration to dedupe results and iteratively rescan newly derived child domains up to the requested depth using a worker pool, while introducing reusable `SubfinderRunner`s and capping concurrent subfinder enumerations to reduce races/rate-limiting; also enforces minimum thread values for passive and reverse DNS configs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86920c8070dfd13bfb4eb5567cc647d74418fdbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->