### PR TITLE
Upgrade Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "3.78.1"
+  "version": "4.68.4"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,9 +3,9 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 0.38.0
+        version: 1.34.5
         config:
-          importpath: github.com/Method-Security/osintscan/generated/go
+          importPath: github.com/Method-Security/osintscan/generated/go
         output:
           location: local-file-system
           path: ../generated/go


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only changes to code generation tooling; risk is limited to potential differences in generated Go output after upgrading Fern/go-sdk versions.
> 
> **Overview**
> Upgrades the Fern project version in `fern.config.json` from `3.78.1` to `4.68.4`.
> 
> Updates the `fern-go-sdk` generator in `generators.yml` from `0.38.0` to `1.34.5` and renames the Go import config key from `importpath` to `importPath`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6282e9c039b9ac53c511ade5e5156cebb1dc5d9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->