### PR TITLE
Add Okta org slug reverse lookup detection

### DIFF
--- a/fern/definition/discover/idp/idp.yml
+++ b/fern/definition/discover/idp/idp.yml
@@ -39,6 +39,7 @@ types:
     - DNS_CNAME
     - OPENID_CONFIG
     - AZURE_USERREALM_FEDERATION
+    - ORG_SLUG_LOOKUP
 
 # Azure-Specific Types
   DetectedM365Service:

--- a/internal/discover/idp.go
+++ b/internal/discover/idp.go
@@ -404,6 +404,36 @@ func detectOkta(ctx context.Context, client *httpclient.Client, domain string, r
 		}
 	}
 
+	// Method 4: Reverse lookup — try {slug}.okta.com OIDC endpoint
+	if !found {
+		for _, slug := range generateOktaOrgSlugs(domain) {
+			oktaOrgHost := fmt.Sprintf("%s.okta.com", slug)
+			oidcURL := fmt.Sprintf("https://%s/.well-known/openid-configuration", oktaOrgHost)
+			var oidc oktaOIDCResponse
+			if _, err := client.GetJSON(ctx, oidcURL, &oidc); err != nil {
+				continue
+			}
+			if oidc.Issuer != "" {
+				found = true
+				details.Issuer = &oidc.Issuer
+				orgURL := fmt.Sprintf("https://%s", oktaOrgHost)
+				details.OrgUrl = &orgURL
+				if oidc.AuthorizationEndpoint != "" {
+					details.AuthorizationEndpoint = &oidc.AuthorizationEndpoint
+				}
+				if oidc.TokenEndpoint != "" {
+					details.TokenEndpoint = &oidc.TokenEndpoint
+				}
+				detectionMethod := idpfern.OktaDetectionMethodOrgSlugLookup
+				details.DetectionMethod = &detectionMethod
+				log.Info("Okta detected via org slug lookup",
+					svc1log.SafeParam("okta_org", oktaOrgHost),
+					svc1log.SafeParam("issuer", oidc.Issuer))
+				break
+			}
+		}
+	}
+
 	if !found {
 		return nil, errors
 	}
@@ -413,4 +443,40 @@ func detectOkta(ctx context.Context, client *httpclient.Client, domain string, r
 		Provider: idpfern.IdpProviderOkta,
 		Okta:     details,
 	}, errors
+}
+
+// generateOktaOrgSlugs produces candidate Okta org slugs from a domain.
+// For "method.security" it yields: ["method-security", "methodsecurity", "method"].
+// For "example.com" it yields: ["example"].
+func generateOktaOrgSlugs(domain string) []string {
+	parts := strings.Split(domain, ".")
+	if len(parts) < 2 {
+		return []string{strings.ToLower(domain)}
+	}
+	name := strings.ToLower(parts[0])
+	tld := strings.ToLower(parts[len(parts)-1])
+
+	seen := map[string]bool{}
+	var slugs []string
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			slugs = append(slugs, s)
+		}
+	}
+
+	// For non-traditional TLDs (not com/net/org/edu/gov/io), the TLD
+	// may be part of the brand name (e.g., method.security → method-security)
+	commonTLDs := map[string]bool{
+		"com": true, "net": true, "org": true, "edu": true, "gov": true,
+		"io": true, "co": true, "us": true, "uk": true, "ca": true,
+		"au": true, "de": true, "fr": true, "jp": true, "in": true,
+	}
+	if !commonTLDs[tld] {
+		add(name + "-" + tld)
+		add(name + tld)
+	}
+	add(name)
+
+	return slugs
 }


### PR DESCRIPTION
## Summary
- Adds a 4th Okta detection method (`ORG_SLUG_LOOKUP`) to the `discover idp` command
- When DNS CNAME, OpenID config, and Azure UserRealm federation checks all fail, tries `{slug}.okta.com/.well-known/openid-configuration` for candidate org slugs derived from the domain
- For `method.security`, generates slugs: `method-security`, `methodsecurity`, `method` — successfully finds `methodsecurity.okta.com`
- New `ORG_SLUG_LOOKUP` enum value in `OktaDetectionMethod` Fern definition

## Related PRs
- ontology-definition: method-security/ontology-definition#453 (adds `ORG_SLUG_LOOKUP` to `DetectionMethodEnum`)
- ontology: method-security/ontology#1235 (processor + tests)

## Test plan
- [x] `./godelw verify` passes
- [x] Binary tested against `method.security` — detects Okta via `methodsecurity.okta.com` with `ORG_SLUG_LOOKUP` detection method
- [x] Ontology processor test passes with real signal data from `method.security`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new network-based Okta detection fallback that probes candidate `{slug}.okta.com` OIDC endpoints; risk is mainly extra outbound requests and potential false positives/latency in IdP discovery.
> 
> **Overview**
> Improves Okta IdP discovery by adding a fourth fallback detection method, `ORG_SLUG_LOOKUP`, which tries candidate `{slug}.okta.com/.well-known/openid-configuration` endpoints when existing DNS, OIDC-subdomain, and Azure UserRealm checks fail.
> 
> Extends the Fern API enum `OktaDetectionMethod` with `ORG_SLUG_LOOKUP` and populates Okta discovery details (issuer/org URL and token/auth endpoints when present) based on a new `generateOktaOrgSlugs(domain)` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce4528bcda0ad6d7714329acc82f25c2b7435f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->