### PR TITLE
Update Active DNS Logic

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -369,6 +369,16 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			wildcardChecks, err := cmd.Flags().GetInt("wildcard-checks")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
+			wildcardRecheck, err := cmd.Flags().GetBool("wildcard-recheck")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -381,9 +391,9 @@ func (a *OsintScan) InitDiscoverCommand() {
 					return
 				}
 			}
-			config := getDiscoverDNSActiveSubdomainConfig(domain, allSubdomains, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, sleep, dnsResolvers)
+			config := getDiscoverDNSActiveSubdomainConfig(domain, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, sleep, wildcardChecks, wildcardRecheck, dnsResolvers)
 
-			report, err := subdomain.GetDomainSubdomainsActive(cmd.Context(), config)
+			report, err := subdomain.GetDomainSubdomainsActive(cmd.Context(), allSubdomains, config)
 			if err != nil {
 				a.OutputSignal.AddError(err)
 				return
@@ -403,6 +413,8 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainActiveCmd.Flags().Int("max-depth", 2, "Maximum recursion depth for subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 0, "Maximum time (in minutes) to spend on subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("sleep", 0, "Sleep time in milliseconds between requests to avoid rate limiting")
+	discoverDNSSubdomainActiveCmd.Flags().Int("wildcard-checks", 3, "Number of random subdomain probes used to detect wildcard DNS records")
+	discoverDNSSubdomainActiveCmd.Flags().Bool("wildcard-recheck", false, "Re-run wildcard detection after brute force and discard results if wildcard is found")
 	discoverDNSSubdomainActiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
 
 	// Mark Required Flags
@@ -849,19 +861,20 @@ func getDiscoverDNSReverseConfig(ips []string, cidr string, dnsResolvers []strin
 }
 
 // getDiscoverDNSActiveSubdomainConfig creates and returns a configuration for active subdomain discovery
-func getDiscoverDNSActiveSubdomainConfig(domain string, subdomains []string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout, sleep int, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
+func getDiscoverDNSActiveSubdomainConfig(domain string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout, sleep, wildcardChecks int, wildcardRecheck bool, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
 	return dnsfern.DiscoverDnsSubdomainConfig{
 		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeActive)),
 		Active: &dnsfern.DiscoverDnsSubdomainActiveConfig{
-			Domain:       domain,
-			Subdomains:   subdomains,
-			WordlistSize: wordlistSize,
-			WordlistFile: wordlistFile,
-			Threads:      threads,
-			MaxDepth:     maxDepth,
-			Timeout:      timeout,
-			Sleep:        sleep,
-			DnsResolvers: dnsResolvers,
+			Domain:          domain,
+			WordlistSize:    wordlistSize,
+			WordlistFile:    wordlistFile,
+			Threads:         threads,
+			MaxDepth:        maxDepth,
+			Timeout:         timeout,
+			Sleep:           sleep,
+			WildcardChecks:  wildcardChecks,
+			WildcardRecheck: wildcardRecheck,
+			DnsResolvers:    dnsResolvers,
 		},
 	}
 }

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -20,13 +20,14 @@ types:
   DiscoverDnsSubdomainActiveConfig:
     properties:
       domain: string
-      subdomains: optional<list<string>>
       wordlistSize: optional<WordlistSize>
       wordlistFile: optional<string>
       threads: integer
       maxDepth: integer
       timeout: integer
       sleep: integer
+      wildcardChecks: integer
+      wildcardRecheck: boolean
       dnsResolvers: optional<list<string>>
   DiscoverDnsSubdomainCorrelationConfig:
     properties:

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -18,12 +18,12 @@ import (
 
 // GetDomainSubdomainsActive performs active (bruteforce) subdomain discovery for a given domain.
 // Returns a report containing all discovered subdomains and any errors encountered.
-func GetDomainSubdomainsActive(ctx context.Context, config dnsfern.DiscoverDnsSubdomainConfig) (dnsfern.DiscoverDnsSubdomainReport, error) {
+func GetDomainSubdomainsActive(ctx context.Context, subdomains []string, config dnsfern.DiscoverDnsSubdomainConfig) (dnsfern.DiscoverDnsSubdomainReport, error) {
 	activeConfig := config.GetActive()
 	errors := []string{}
 
 	// Run the active subdomain discovery
-	subdomains, err := getSubdomainsActive(ctx, activeConfig.Domain, activeConfig.Subdomains, activeConfig.Threads, activeConfig.MaxDepth, activeConfig.Timeout, activeConfig.Sleep, activeConfig.DnsResolvers)
+	subdomains, err := getSubdomainsActive(ctx, activeConfig.Domain, subdomains, activeConfig.Threads, activeConfig.MaxDepth, activeConfig.Timeout, activeConfig.Sleep, activeConfig.WildcardChecks, activeConfig.WildcardRecheck, activeConfig.DnsResolvers)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
@@ -42,7 +42,7 @@ func GetDomainSubdomainsActive(ctx context.Context, config dnsfern.DiscoverDnsSu
 }
 
 // getSubdomainsActive performs recursive bruteforce subdomain enumeration with concurrency and wildcard detection.
-func getSubdomainsActive(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, sleep int, dnsServerAddresses []string) ([]string, error) {
+func getSubdomainsActive(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, sleep int, wildcardChecks int, wildcardRecheck bool, dnsServerAddresses []string) ([]string, error) {
 	log := svc1log.FromContext(ctx)
 	subdomains := []string{}
 	subdomainsSet := make(map[string]struct{}) // To track unique valid subdomains
@@ -59,13 +59,13 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 	// First iteration - test all base subdomains for wildcards
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
-	wildcardDNS, err := detectWildcardDNS(ctx, domain, resolvers[0])
+	wildcardIPs, err := detectWildcardDNS(ctx, domain, resolvers[0], wildcardChecks)
 	if err != nil {
 		return []string{}, err
 	}
-	if wildcardDNS != nil {
+	if wildcardIPs != nil {
 		// Wildcard DNS detected - skip brute forcing to avoid false positives
-		log.Info("Wildcard DNS detected, skipping brute force", svc1log.SafeParam("wildcard", *wildcardDNS))
+		log.Info("Wildcard DNS detected, skipping brute force", svc1log.SafeParam("wildcard", "*."+domain))
 		return subdomains, nil
 	}
 
@@ -90,15 +90,15 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 		validSubdomains := []string{}
 		for _, subdomain := range currentDepthSubdomains {
-			wildcardDNS, err := detectWildcardDNS(ctx, subdomain, resolvers[0]) // Use resolvers[0] for wildcard detection
+			depthWildcardIPs, err := detectWildcardDNS(ctx, subdomain, resolvers[0], wildcardChecks)
 			if err != nil {
 				continue
 			}
-			if wildcardDNS != nil {
+			if depthWildcardIPs != nil {
 				// Wildcard DNS detected for this subdomain - skip to avoid false positives
 				log.Info("Wildcard DNS detected for subdomain, skipping",
 					svc1log.SafeParam("subdomain", subdomain),
-					svc1log.SafeParam("wildcard", *wildcardDNS))
+					svc1log.SafeParam("wildcard", "*."+subdomain))
 				continue
 			}
 			validSubdomains = append(validSubdomains, subdomain)
@@ -106,6 +106,19 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 		newPermutations := generatePermutations(validSubdomains, subdomainList)
 		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep)
+	}
+
+	// Post-brute-force wildcard re-check: re-probe the base domain to catch wildcards
+	// that the initial detection missed due to transient DNS failures
+	if wildcardRecheck && len(subdomains) > 0 {
+		log.Info("Running post-scan wildcard re-check", svc1log.SafeParam("domain", domain))
+		recheckWildcardIPs, recheckErr := detectWildcardDNS(ctx, domain, resolvers[0], wildcardChecks)
+		if recheckErr == nil && recheckWildcardIPs != nil {
+			log.Info("Post-scan wildcard DNS detected, discarding all results",
+				svc1log.SafeParam("domain", domain),
+				svc1log.SafeParam("discarded_count", len(subdomains)))
+			subdomains = []string{}
+		}
 	}
 
 	return subdomains, nil

--- a/internal/discover/dns/subdomain/correlation.go
+++ b/internal/discover/dns/subdomain/correlation.go
@@ -132,16 +132,16 @@ func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *n
 	}
 
 	// Check for wildcard DNS - test the full FQDN directly
-	wildcardDomain, err := detectWildcardDNS(lookupCtx, fqdn, resolver)
+	wildcardIPs, err := detectWildcardDNS(lookupCtx, fqdn, resolver, 3)
 	if err != nil {
 		log.Warn("Failed to detect wildcard DNS",
 			svc1log.SafeParam("fqdn", fqdn),
 			svc1log.SafeParam("error", err.Error()))
 		return false, fmt.Errorf("wildcard detection failed: %v", err)
-	} else if wildcardDomain != nil {
+	} else if wildcardIPs != nil {
 		log.Info("Wildcard DNS detected",
 			svc1log.SafeParam("fqdn", fqdn),
-			svc1log.SafeParam("wildcard_domain", *wildcardDomain))
+			svc1log.SafeParam("wildcard_ips", wildcardIPs))
 		return false, nil
 	}
 

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -9,32 +9,31 @@ import (
 	"net"
 )
 
-// detectWildcardDNS tests a random high-entropy subdomain to check if a wildcard DNS record is present.
-// Returns the wildcard domain if detected, otherwise nil.
-func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolver) (*string, error) {
-	// Generate a high-entropy 16-character random subdomain
-	randomSubdomain, err := generateRandomSubdomain(domain)
-	if err != nil {
-		return nil, err
+// detectWildcardDNS tests multiple random high-entropy subdomains to check if a wildcard DNS record is present.
+// Returns a non-nil slice if wildcard is detected, nil if no wildcard.
+// Using multiple probes reduces the chance of a single false result.
+func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolver, wildcardChecks int) ([]string, error) {
+	for i := 0; i < wildcardChecks; i++ {
+		randomSubdomain, err := generateRandomSubdomain(domain)
+		if err != nil {
+			return nil, err
+		}
+
+		ips, err := resolver.LookupHost(ctx, randomSubdomain)
+		if err == nil {
+			// Random subdomain resolved - wildcard is present
+			return ips, nil
+		}
+
+		if !isDNSNotFound(err) {
+			// Non-NXDOMAIN error (timeout, SERVFAIL, etc.) - DNS is unreliable
+			return nil, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
+		}
+		// NXDOMAIN - this probe says no wildcard, try next probe
 	}
 
-	// Check if the random subdomain resolves
-	_, err = resolver.LookupHost(ctx, randomSubdomain)
-
-	// If no error, it resolved, meaning wildcard is present
-	if err == nil {
-		wildcardDomain := "*." + domain
-		return &wildcardDomain, nil
-	}
-
-	// Check if it's specifically NXDOMAIN (domain doesn't exist)
-	if isDNSNotFound(err) {
-		// NXDOMAIN = no wildcard, safe to continue
-		return nil, nil
-	}
-
-	// Any other DNS error = fail fast, don't continue with potentially unreliable results
-	return nil, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
+	// All probes returned NXDOMAIN - no wildcard
+	return nil, nil
 }
 
 // generateRandomSubdomain generates a high-entropy subdomain with only letters (16 characters).


### PR DESCRIPTION
 Fixes intermittent wildcard DNS detection failures that allowed false positive subdomains through during active brute force discovery. A single random probe was not reliable enough — multiple probes reduce the chance of a single false result deciding the outcome.
                                                                                                                                    
  - detectWildcardDNS now runs N probes (default 3) instead of 1 — if ANY resolve, wildcard is detected; returns early on first     
  match
  - New --wildcard-checks flag to configure probe count                                                                             
  - New --wildcard-recheck flag (default false) to re-probe after brute force and discard all results if wildcard is detected 
  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the active subdomain discovery API/config and wildcard detection behavior, which can affect scan results (false positives/negatives) and may break callers relying on the previous config shape.
> 
> **Overview**
> Improves *active* DNS subdomain discovery wildcard handling by switching wildcard detection from a single random probe to **N configurable probes** and treating non-NXDOMAIN lookup errors as failures to avoid unreliable results.
> 
> Adds `--wildcard-checks` (default `3`) and an optional `--wildcard-recheck` pass that re-tests for wildcards after brute force and **discards all discovered subdomains** if a wildcard is detected.
> 
> Updates the Fern `DiscoverDnsSubdomainActiveConfig` schema and refactors the active discovery call path to pass the subdomain list separately from the generated config, propagating the new wildcard settings through `cmd/discover.go` and the internal active/correlation implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da2ba2e8e5cee783d4f3e1a534e3adf559d5956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->