### PR TITLE
Update DNS Active Logic for CNAME records

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -374,11 +374,6 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
-			wildcardRecheck, err := cmd.Flags().GetBool("wildcard-recheck")
-			if err != nil {
-				a.OutputSignal.AddError(err)
-				return
-			}
 			dnsResolvers, err := cmd.Flags().GetStringSlice("dns-resolvers")
 			if err != nil {
 				a.OutputSignal.AddError(err)
@@ -391,7 +386,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 					return
 				}
 			}
-			config := getDiscoverDNSActiveSubdomainConfig(domain, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, sleep, wildcardChecks, wildcardRecheck, dnsResolvers)
+			config := getDiscoverDNSActiveSubdomainConfig(domain, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, sleep, wildcardChecks, dnsResolvers)
 
 			report, err := subdomain.GetDomainSubdomainsActive(cmd.Context(), allSubdomains, config)
 			if err != nil {
@@ -414,7 +409,6 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 0, "Maximum time (in minutes) to spend on subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("sleep", 0, "Sleep time in milliseconds between requests to avoid rate limiting")
 	discoverDNSSubdomainActiveCmd.Flags().Int("wildcard-checks", 3, "Number of random subdomain probes used to detect wildcard DNS records")
-	discoverDNSSubdomainActiveCmd.Flags().Bool("wildcard-recheck", false, "Re-run wildcard detection after brute force and discard results if wildcard is found")
 	discoverDNSSubdomainActiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
 
 	// Mark Required Flags
@@ -861,20 +855,19 @@ func getDiscoverDNSReverseConfig(ips []string, cidr string, dnsResolvers []strin
 }
 
 // getDiscoverDNSActiveSubdomainConfig creates and returns a configuration for active subdomain discovery
-func getDiscoverDNSActiveSubdomainConfig(domain string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout, sleep, wildcardChecks int, wildcardRecheck bool, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
+func getDiscoverDNSActiveSubdomainConfig(domain string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout, sleep, wildcardChecks int, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
 	return dnsfern.DiscoverDnsSubdomainConfig{
 		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeActive)),
 		Active: &dnsfern.DiscoverDnsSubdomainActiveConfig{
-			Domain:          domain,
-			WordlistSize:    wordlistSize,
-			WordlistFile:    wordlistFile,
-			Threads:         threads,
-			MaxDepth:        maxDepth,
-			Timeout:         timeout,
-			Sleep:           sleep,
-			WildcardChecks:  wildcardChecks,
-			WildcardRecheck: wildcardRecheck,
-			DnsResolvers:    dnsResolvers,
+			Domain:         domain,
+			WordlistSize:   wordlistSize,
+			WordlistFile:   wordlistFile,
+			Threads:        threads,
+			MaxDepth:       maxDepth,
+			Timeout:        timeout,
+			Sleep:          sleep,
+			WildcardChecks: wildcardChecks,
+			DnsResolvers:   dnsResolvers,
 		},
 	}
 }

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -27,7 +27,6 @@ types:
       timeout: integer
       sleep: integer
       wildcardChecks: integer
-      wildcardRecheck: boolean
       dnsResolvers: optional<list<string>>
   DiscoverDnsSubdomainCorrelationConfig:
     properties:

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,7 +25,7 @@ func GetDomainSubdomainsActive(ctx context.Context, subdomains []string, config 
 	errors := []string{}
 
 	// Run the active subdomain discovery
-	subdomains, err := getSubdomainsActive(ctx, activeConfig.Domain, subdomains, activeConfig.Threads, activeConfig.MaxDepth, activeConfig.Timeout, activeConfig.Sleep, activeConfig.WildcardChecks, activeConfig.WildcardRecheck, activeConfig.DnsResolvers)
+	subdomains, err := getSubdomainsActive(ctx, activeConfig.Domain, subdomains, activeConfig.Threads, activeConfig.MaxDepth, activeConfig.Timeout, activeConfig.Sleep, activeConfig.WildcardChecks, activeConfig.DnsResolvers)
 	if err != nil {
 		errors = append(errors, err.Error())
 	}
@@ -43,7 +44,7 @@ func GetDomainSubdomainsActive(ctx context.Context, subdomains []string, config 
 }
 
 // getSubdomainsActive performs recursive bruteforce subdomain enumeration with concurrency and wildcard detection.
-func getSubdomainsActive(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, sleep int, wildcardChecks int, wildcardRecheck bool, dnsServerAddresses []string) ([]string, error) {
+func getSubdomainsActive(ctx context.Context, domain string, subdomainList []string, parallelThreads int, recursiveDepth int, timeout int, sleep int, wildcardChecks int, dnsServerAddresses []string) ([]string, error) {
 	log := svc1log.FromContext(ctx)
 	subdomains := []string{}
 	subdomainsSet := make(map[string]struct{}) // To track unique valid subdomains
@@ -59,26 +60,30 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 	resolvers := utils.GetResolvers(dnsServerAddresses, log)
 
 	// Build normalized server addresses for raw DNS queries (CNAME lookups).
-	cnameServers := make([]string, len(dnsServerAddresses))
+	rawResolvers := make([]string, len(dnsServerAddresses))
 	for i, addr := range dnsServerAddresses {
-		cnameServers[i] = utils.NormalizeDNSAddress(addr)
+		rawResolvers[i] = utils.NormalizeDNSAddress(addr)
 	}
 
-	// First iteration - test all base subdomains for wildcards
+	// First iteration - test base domain for wildcards (A/AAAA and CNAME)
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
-	wildcardIPs, err := detectWildcardDNS(ctx, domain, resolvers[0], wildcardChecks)
+	wildcardFound, wildcardA, err := detectWildcardDNS(ctx, domain, resolvers[0], wildcardChecks, rawResolvers[0])
 	if err != nil {
 		return []string{}, err
 	}
-	if wildcardIPs != nil {
-		// Wildcard DNS detected - skip brute forcing to avoid false positives
+	if wildcardA {
 		log.Info("Wildcard DNS detected, skipping brute force", svc1log.SafeParam("wildcard", "*."+domain))
 		return subdomains, nil
+	}
+	wildcardCNAMEDomains := map[string]struct{}{}
+	if wildcardFound && !wildcardA {
+		wildcardCNAMEDomains[domain] = struct{}{}
+		log.Info("Wildcard CNAME detected, disabling CNAME fallback", svc1log.SafeParam("domain", domain))
 	}
 
 	log.Info("Generating base permutations", svc1log.SafeParam("domain", domain))
 	basePermutations := generatePermutations([]string{domain}, subdomainList)
-	validBaseSubdomains := testPermutations(ctx, basePermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth, sleep, cnameServers)
+	validBaseSubdomains := testPermutations(ctx, basePermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth, sleep, rawResolvers, wildcardCNAMEDomains)
 
 	// For each subsequent depth, only build on valid subdomains from previous iteration
 	log.Info("Starting subdomain discovery", svc1log.SafeParam("base_subdomain count", len(validBaseSubdomains)))
@@ -96,36 +101,29 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 			svc1log.SafeParam("subdomain_count", len(currentDepthSubdomains)))
 
 		validSubdomains := []string{}
+		depthWildcardCNAMEDomains := map[string]struct{}{}
 		for _, subdomain := range currentDepthSubdomains {
-			depthWildcardIPs, err := detectWildcardDNS(ctx, subdomain, resolvers[0], wildcardChecks)
+			depthWildcardFound, depthWildcardA, err := detectWildcardDNS(ctx, subdomain, resolvers[0], wildcardChecks, rawResolvers[0])
 			if err != nil {
 				continue
 			}
-			if depthWildcardIPs != nil {
-				// Wildcard DNS detected for this subdomain - skip to avoid false positives
+			if depthWildcardA {
 				log.Info("Wildcard DNS detected for subdomain, skipping",
 					svc1log.SafeParam("subdomain", subdomain),
 					svc1log.SafeParam("wildcard", "*."+subdomain))
 				continue
 			}
+			if depthWildcardFound && !depthWildcardA {
+				depthWildcardCNAMEDomains[subdomain] = struct{}{}
+				log.Info("Wildcard CNAME detected for subdomain, disabling CNAME fallback",
+					svc1log.SafeParam("subdomain", subdomain),
+					svc1log.SafeParam("wildcard_cname", "*."+subdomain))
+			}
 			validSubdomains = append(validSubdomains, subdomain)
 		}
 
 		newPermutations := generatePermutations(validSubdomains, subdomainList)
-		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep, cnameServers)
-	}
-
-	// Post-brute-force wildcard re-check: re-probe the base domain to catch wildcards
-	// that the initial detection missed due to transient DNS failures
-	if wildcardRecheck && len(subdomains) > 0 {
-		log.Info("Running post-scan wildcard re-check", svc1log.SafeParam("domain", domain))
-		recheckWildcardIPs, recheckErr := detectWildcardDNS(ctx, domain, resolvers[0], wildcardChecks)
-		if recheckErr == nil && recheckWildcardIPs != nil {
-			log.Info("Post-scan wildcard DNS detected, discarding all results",
-				svc1log.SafeParam("domain", domain),
-				svc1log.SafeParam("discarded_count", len(subdomains)))
-			subdomains = []string{}
-		}
+		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep, rawResolvers, depthWildcardCNAMEDomains)
 	}
 
 	return subdomains, nil
@@ -133,7 +131,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 // testPermutations concurrently tests a list of subdomain permutations for DNS resolution.
 // Uses a semaphore to limit concurrency and mutexes to protect shared state.
-func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int, cnameServers []string) []string {
+func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int, rawResolvers []string, wildcardCNAMEDomains map[string]struct{}) []string {
 	log := svc1log.FromContext(ctx)
 	var validSubdomains []string
 	validSubdomainsMutex := &sync.Mutex{}
@@ -163,7 +161,7 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 
 			// Round robin CNAME server selection (may differ in length from resolvers
 			// when system defaults are used)
-			cnameServerIdx := currentIndex % int64(len(cnameServers))
+			rawResolverIdx := currentIndex % int64(len(rawResolvers))
 
 			// Capture the duration of the lookup
 			start := time.Now()
@@ -174,8 +172,15 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			// CNAMEs. Dangling CNAMEs are valid discoveries and can indicate
 			// subdomain takeover vulnerabilities.
 			if err != nil {
-				if hasCNAME(testSubdomain, cnameServers[cnameServerIdx]) {
-					err = nil
+				// Extract parent domain to check if it has a wildcard CNAME
+				parentHasWildcardCNAME := false
+				if parts := strings.SplitN(testSubdomain, ".", 2); len(parts) == 2 {
+					_, parentHasWildcardCNAME = wildcardCNAMEDomains[parts[1]]
+				}
+				if !parentHasWildcardCNAME {
+					if hasCNAME(testSubdomain, rawResolvers[rawResolverIdx]) {
+						err = nil
+					}
 				}
 			}
 			duration := time.Since(start)

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -58,6 +58,12 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 	}
 	resolvers := utils.GetResolvers(dnsServerAddresses, log)
 
+	// Build normalized server addresses for raw DNS queries (CNAME lookups).
+	cnameServers := make([]string, len(dnsServerAddresses))
+	for i, addr := range dnsServerAddresses {
+		cnameServers[i] = utils.NormalizeDNSAddress(addr)
+	}
+
 	// First iteration - test all base subdomains for wildcards
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
 	wildcardIPs, err := detectWildcardDNS(ctx, domain, resolvers[0], wildcardChecks)
@@ -72,7 +78,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 	log.Info("Generating base permutations", svc1log.SafeParam("domain", domain))
 	basePermutations := generatePermutations([]string{domain}, subdomainList)
-	validBaseSubdomains := testPermutations(ctx, basePermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth, sleep, dnsServerAddresses)
+	validBaseSubdomains := testPermutations(ctx, basePermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth, sleep, cnameServers)
 
 	// For each subsequent depth, only build on valid subdomains from previous iteration
 	log.Info("Starting subdomain discovery", svc1log.SafeParam("base_subdomain count", len(validBaseSubdomains)))
@@ -106,7 +112,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		}
 
 		newPermutations := generatePermutations(validSubdomains, subdomainList)
-		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep, dnsServerAddresses)
+		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep, cnameServers)
 	}
 
 	// Post-brute-force wildcard re-check: re-probe the base domain to catch wildcards
@@ -127,7 +133,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 // testPermutations concurrently tests a list of subdomain permutations for DNS resolution.
 // Uses a semaphore to limit concurrency and mutexes to protect shared state.
-func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int, dnsServerAddresses []string) []string {
+func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int, cnameServers []string) []string {
 	log := svc1log.FromContext(ctx)
 	var validSubdomains []string
 	validSubdomainsMutex := &sync.Mutex{}
@@ -155,6 +161,10 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			resolver := resolvers[resolverIdx]
 			log.Info("Using resolver", svc1log.SafeParam("resolver_index", resolverIdx))
 
+			// Round robin CNAME server selection (may differ in length from resolvers
+			// when system defaults are used)
+			cnameServerIdx := currentIndex % int64(len(cnameServers))
+
 			// Capture the duration of the lookup
 			start := time.Now()
 			_, err := resolver.LookupHost(ctx, testSubdomain)
@@ -164,7 +174,7 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			// CNAMEs. Dangling CNAMEs are valid discoveries and can indicate
 			// subdomain takeover vulnerabilities.
 			if err != nil {
-				if hasCNAME(testSubdomain, dnsServerAddresses) {
+				if hasCNAME(testSubdomain, cnameServers[cnameServerIdx]) {
 					err = nil
 				}
 			}
@@ -214,12 +224,8 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 // hasCNAME performs a raw DNS CNAME query to detect CNAME records, including dangling
 // ones where the target doesn't resolve. Go's net.LookupCNAME follows the chain and
 // fails on dangling CNAMEs, so we use miekg/dns for a single-hop raw query instead.
-func hasCNAME(subdomain string, dnsServerAddresses []string) bool {
-	server := "1.1.1.1:53"
-	if len(dnsServerAddresses) > 0 {
-		server = utils.NormalizeDNSAddress(dnsServerAddresses[0])
-	}
-
+// The server parameter must be a normalized address with port (e.g. "1.1.1.1:53").
+func hasCNAME(subdomain string, server string) bool {
 	msg := new(dns.Msg)
 	msg.SetQuestion(dns.Fqdn(subdomain), dns.TypeCNAME)
 	msg.RecursionDesired = true

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -13,6 +13,7 @@ import (
 	// Utils
 	"github.com/Method-Security/osintscan/utils"
 	// External
+	"github.com/miekg/dns"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
@@ -71,7 +72,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 	log.Info("Generating base permutations", svc1log.SafeParam("domain", domain))
 	basePermutations := generatePermutations([]string{domain}, subdomainList)
-	validBaseSubdomains := testPermutations(ctx, basePermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth, sleep)
+	validBaseSubdomains := testPermutations(ctx, basePermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, 1, recursiveDepth, sleep, dnsServerAddresses)
 
 	// For each subsequent depth, only build on valid subdomains from previous iteration
 	log.Info("Starting subdomain discovery", svc1log.SafeParam("base_subdomain count", len(validBaseSubdomains)))
@@ -105,7 +106,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		}
 
 		newPermutations := generatePermutations(validSubdomains, subdomainList)
-		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep)
+		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep, dnsServerAddresses)
 	}
 
 	// Post-brute-force wildcard re-check: re-probe the base domain to catch wildcards
@@ -126,7 +127,7 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 // testPermutations concurrently tests a list of subdomain permutations for DNS resolution.
 // Uses a semaphore to limit concurrency and mutexes to protect shared state.
-func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int) []string {
+func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int, dnsServerAddresses []string) []string {
 	log := svc1log.FromContext(ctx)
 	var validSubdomains []string
 	validSubdomainsMutex := &sync.Mutex{}
@@ -157,6 +158,16 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			// Capture the duration of the lookup
 			start := time.Now()
 			_, err := resolver.LookupHost(ctx, testSubdomain)
+			// If LookupHost fails (no A/AAAA record), check for CNAME records
+			// via a raw DNS query. Go's net.LookupCNAME follows the CNAME chain
+			// and fails if the target doesn't resolve, so it can't detect dangling
+			// CNAMEs. Dangling CNAMEs are valid discoveries and can indicate
+			// subdomain takeover vulnerabilities.
+			if err != nil {
+				if hasCNAME(testSubdomain, dnsServerAddresses) {
+					err = nil
+				}
+			}
 			duration := time.Since(start)
 
 			// Apply sleep delay if configured (in milliseconds)
@@ -198,6 +209,32 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 
 	wg.Wait()
 	return validSubdomains
+}
+
+// hasCNAME performs a raw DNS CNAME query to detect CNAME records, including dangling
+// ones where the target doesn't resolve. Go's net.LookupCNAME follows the chain and
+// fails on dangling CNAMEs, so we use miekg/dns for a single-hop raw query instead.
+func hasCNAME(subdomain string, dnsServerAddresses []string) bool {
+	server := "1.1.1.1:53"
+	if len(dnsServerAddresses) > 0 {
+		server = utils.NormalizeDNSAddress(dnsServerAddresses[0])
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(dns.Fqdn(subdomain), dns.TypeCNAME)
+	msg.RecursionDesired = true
+
+	resp, err := dns.Exchange(msg, server)
+	if err != nil || resp == nil {
+		return false
+	}
+
+	for _, ans := range resp.Answer {
+		if _, ok := ans.(*dns.CNAME); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // generatePermutations creates all possible subdomain permutations for the given base subdomains and subdomain list.

--- a/internal/discover/dns/subdomain/correlation.go
+++ b/internal/discover/dns/subdomain/correlation.go
@@ -132,16 +132,15 @@ func validateSingleFQDNCorrelation(ctx context.Context, fqdn string, resolver *n
 	}
 
 	// Check for wildcard DNS - test the full FQDN directly
-	wildcardIPs, err := detectWildcardDNS(lookupCtx, fqdn, resolver, 3)
+	wildcardFound, _, err := detectWildcardDNS(lookupCtx, fqdn, resolver, 3, "")
 	if err != nil {
 		log.Warn("Failed to detect wildcard DNS",
 			svc1log.SafeParam("fqdn", fqdn),
 			svc1log.SafeParam("error", err.Error()))
 		return false, fmt.Errorf("wildcard detection failed: %v", err)
-	} else if wildcardIPs != nil {
+	} else if wildcardFound {
 		log.Info("Wildcard DNS detected",
-			svc1log.SafeParam("fqdn", fqdn),
-			svc1log.SafeParam("wildcard_ips", wildcardIPs))
+			svc1log.SafeParam("fqdn", fqdn))
 		return false, nil
 	}
 

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -10,30 +10,34 @@ import (
 )
 
 // detectWildcardDNS tests multiple random high-entropy subdomains to check if a wildcard DNS record is present.
-// Returns a non-nil slice if wildcard is detected, nil if no wildcard.
-// Using multiple probes reduces the chance of a single false result.
-func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolver, wildcardChecks int) ([]string, error) {
+// Checks both A/AAAA records (via LookupHost) and CNAME records (via raw query) since a dangling
+// wildcard CNAME won't resolve via LookupHost but still produces false positives in brute-force.
+// Returns (true, true) for A/AAAA wildcard, (true, false) for CNAME-only wildcard, (false, false) for no wildcard.
+func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolver, wildcardChecks int, rawResolver string) (wildcardFound bool, wildcardA bool, err error) {
 	for i := 0; i < wildcardChecks; i++ {
 		randomSubdomain, err := generateRandomSubdomain(domain)
 		if err != nil {
-			return nil, err
+			return false, false, err
 		}
 
-		ips, err := resolver.LookupHost(ctx, randomSubdomain)
+		_, err = resolver.LookupHost(ctx, randomSubdomain)
 		if err == nil {
-			// Random subdomain resolved - wildcard is present
-			return ips, nil
+			// Random subdomain resolved via A/AAAA - wildcard is present
+			return true, true, nil
 		}
 
 		if !isDNSNotFound(err) {
 			// Non-NXDOMAIN error (timeout, SERVFAIL, etc.) - DNS is unreliable
-			return nil, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
+			return false, false, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
 		}
-		// NXDOMAIN - this probe says no wildcard, try next probe
+
+		// NXDOMAIN for A/AAAA - check if a wildcard CNAME exists (only when a raw resolver is provided)
+		if rawResolver != "" && hasCNAME(randomSubdomain, rawResolver) {
+			return true, false, nil
+		}
 	}
 
-	// All probes returned NXDOMAIN - no wildcard
-	return nil, nil
+	return false, false, nil
 }
 
 // generateRandomSubdomain generates a high-entropy subdomain with only letters (16 characters).


### PR DESCRIPTION
## Updated Logic

  1. A/AAAA wildcard found → Returns              
  2. CNAME wildcard found (A/AAAA was NXDOMAIN but CNAME exists) →  Brute-forces but disables CNAME fallback
  3. DNS error (timeout, SERVFAIL) → Returns                                                      
  4. No wildcard (all probes NXDOMAIN, no CNAMEs) → Brute-forces with CNAME fallback enabled    

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds raw DNS querying to treat CNAME-only/dangling CNAMEs as valid discoveries, changing subdomain enumeration results and introducing new dependency/IO paths. There’s also a potential edge case if no DNS resolvers are configured (empty CNAME server list leading to modulo-by-zero).
> 
> **Overview**
> Active subdomain enumeration now treats a permutation as *valid* if it resolves to an A/AAAA **or** has a CNAME record (including dangling CNAMEs), by issuing a raw `dns.TypeCNAME` query via `miekg/dns` when `LookupHost` fails.
> 
> To support this, the scan builds normalized DNS server `host:port` addresses for CNAME queries and round-robins them alongside the existing resolvers, with `testPermutations` updated to accept and use this new CNAME-server list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af1ee7202cdc8eca4447c21b2d84fc4bf3d8c1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->