### PR TITLE
Update Active DNS Logging + CNAME

### DIFF
--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -171,7 +171,9 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			// and fails if the target doesn't resolve, so it can't detect dangling
 			// CNAMEs. Dangling CNAMEs are valid discoveries and can indicate
 			// subdomain takeover vulnerabilities.
-			if err != nil {
+			// Only attempt CNAME detection on a definitive NXDOMAIN — SERVFAIL,
+			// timeouts, and other transient errors must not trigger the CNAME path.
+			if err != nil && isDNSNotFound(err) {
 				// Extract parent domain to check if it has a wildcard CNAME
 				parentHasWildcardCNAME := false
 				if parts := strings.SplitN(testSubdomain, ".", 2); len(parts) == 2 {
@@ -209,15 +211,18 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			// If the subdomain is found, add it to the list
 			if err == nil {
 				subdomainsMutex.Lock()
-				if _, exists := subdomainsSet[testSubdomain]; !exists {
+				_, exists := subdomainsSet[testSubdomain]
+				if !exists {
 					subdomainsSet[testSubdomain] = struct{}{}
 					*subdomains = append(*subdomains, testSubdomain)
 				}
 				subdomainsMutex.Unlock()
 
-				validSubdomainsMutex.Lock()
-				validSubdomains = append(validSubdomains, testSubdomain)
-				validSubdomainsMutex.Unlock()
+				if !exists {
+					validSubdomainsMutex.Lock()
+					validSubdomains = append(validSubdomains, testSubdomain)
+					validSubdomainsMutex.Unlock()
+				}
 			}
 		}(testSubdomain)
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes DNS error-handling and discovery semantics, which can affect enumeration results and recursion breadth; behavior should be validated against real-world resolver error cases.
> 
> **Overview**
> Active subdomain discovery now only falls back to raw CNAME probing when `LookupHost` returns a definitive NXDOMAIN (via `isDNSNotFound`), avoiding treating transient DNS errors (timeouts/SERVFAIL) as discoveries.
> 
> It also fixes a duplication issue by only appending to `validSubdomains` when the subdomain was newly added to the global set, keeping per-depth recursion inputs unique.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03627964a3b68732823f4db3041df4ce12188a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->