### PR TITLE
Update Docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: osintscan
 site_url: https://method-security.github.io/osintscan/
-site_description: AWS enumeration capabilities for security teams of all sizes
+site_description: OSINT capabilities for security teams of all sizes
 docs_dir: docs/
 repo_name: GitHub
 repo_url: https://github.com/Method-Security/osintscan


### PR DESCRIPTION
## Summary

- `site_description` was incorrectly set to `"AWS enumeration capabilities for security teams of all sizes"` — this belongs to `methodaws`, not `osintscan`
- Fixed to `"OSINT capabilities for security teams of all sizes"`

## Test plan

- [x] `mkdocs build --strict` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)