### PR TITLE
Update Docs

### DIFF
--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -79,12 +79,35 @@ Global Flags:
 
 ### IDP
 
-Detect identity providers (Azure AD/Entra ID, Okta, etc.) associated with a domain by querying public endpoints, DNS records, and federation metadata.
+Detect identity providers associated with a domain by querying public endpoints, DNS records, and federation metadata. Supports detection of Azure AD/Entra ID and Okta.
 
 #### Usage
 ```bash
 osintscan discover idp --domain example.com
 ```
+
+#### Azure AD / Entra ID Detection
+
+For domains using Azure AD/Entra ID, the command queries Microsoft's public federation and OpenID endpoints to extract:
+
+- **Tenant details**: Tenant ID, brand name, cloud instance, namespace type
+- **Federation status**: `MANAGED` (password auth via Azure AD), `FEDERATED` (auth delegated to on-prem IdP), or `UNKNOWN`
+- **Federation metadata**: Auth URL, authorization endpoint, token endpoint, OpenID configuration URL
+- **Credential type info**: Desktop SSO (Seamless SSO) status, preferred credential type (`PASSWORD`, `FEDERATION`, `FIDO2`, `WINDOWS_HELLO`, `PHONE_SIGN_IN`), custom branding configured
+- **M365 service presence**: Detects Exchange Online, SharePoint Online, Teams, and Skype for Business (SSFB)
+
+#### Okta Detection
+
+For domains using Okta, the command tries four detection methods in order:
+
+| Method | Description |
+|--------|-------------|
+| `DNS_CNAME` | Checks for a DNS CNAME on the domain pointing to an Okta endpoint |
+| `OPENID_CONFIG` | Fetches the OpenID Connect discovery document from the domain |
+| `AZURE_USERREALM_FEDERATION` | Queries Microsoft's UserRealm API to detect Okta federation |
+| `ORG_SLUG_LOOKUP` | Generates candidate org slugs from the domain (e.g., `method.security` → `method-security`, `methodsecurity`, `method`) and probes `{slug}.okta.com` OIDC endpoints |
+
+When detected, returns: org URL, issuer, custom domain, authorization endpoint, token endpoint, and the detection method used.
 
 #### Help Text
 ```bash

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -166,9 +166,10 @@ Usage:
   osintscan discover dns records [flags]
 
 Flags:
-      --domain string          The domain name to query for DNS records
-  -h, --help                   help for records
-      --record-types strings   Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, ALL) (default [ALL])
+      --dns-resolvers strings   DNS resolvers to use for record lookups (e.g. 10.0.0.1:53). Uses public resolvers if not set.
+      --domain string           The domain name to query for DNS records
+  -h, --help                    help for records
+      --record-types strings    Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, ALL) (default [ALL])
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -13,6 +13,7 @@ osintscan discover [command]
 - **asn**: ASN information discovery using BGPView API
 - **cdn**: CDN provider detection for IP addresses and domains
 - **dns**: Comprehensive DNS intelligence gathering
+- **idp**: Identity provider discovery for a domain
 - **ip**: IP address and network intelligence
 - **shodan**: Query the Shodan search engine
 
@@ -64,10 +65,38 @@ Usage:
 
 Flags:
       --domain string                The domain name to check against CDN provider ranges
-      --dns-resolvers stringSlice    Custom DNS resolver/servers to use (default [1.1.1.1:53])
-      --fingerprints-file string     Path to CDN fingerprints file (default "/opt/method/osintscan/var/conf/discover/cdn/providers.json")
+      --dns-resolvers stringSlice    Custom DNS resolver/servers to use
+      --fingerprints-file string     The path to the CDN fingerprints file
   -h, --help                        help for cdn
       --ip-addresses stringSlice    IP addresses to check against CDN provider ranges
+
+Global Flags:
+  -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
+  -f, --output-file string   Path to output file. If blank, will output to STDOUT
+  -q, --quiet                Suppress output
+  -v, --verbose              Verbose output
+```
+
+### IDP
+
+Detect identity providers (Azure AD/Entra ID, Okta, etc.) associated with a domain by querying public endpoints, DNS records, and federation metadata.
+
+#### Usage
+```bash
+osintscan discover idp --domain example.com
+```
+
+#### Help Text
+```bash
+Detect identity providers (Azure AD/Entra ID, Okta, etc.) associated with a domain by querying public endpoints, DNS records, and federation metadata.
+
+Usage:
+  osintscan discover idp [flags]
+
+Flags:
+      --domain string   The domain name to discover identity providers for
+  -h, --help            help for idp
+      --timeout int     The timeout in seconds for each HTTP request (default 30)
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -165,7 +194,7 @@ Usage:
   osintscan discover dns forward [flags]
 
 Flags:
-      --dns-resolvers stringSlice   Custom DNS resolver/servers (default [1.1.1.1:53])
+      --dns-resolvers stringSlice   Custom DNS resolver/servers
       --domain string              Domain name to perform forward lookups on
   -h, --help                      help for forward
 
@@ -195,7 +224,7 @@ Usage:
 
 Flags:
       --cidr string             The CIDR range to perform reverse DNS lookup on
-      --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53) (default [1.1.1.1:53])
+      --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)
   -h, --help                    help for reverse
       --ip-addresses strings    The IP addresses to perform reverse DNS lookup on
       --threads int             Number of concurrent threads for scanning (Default is number of CPUS on machine)
@@ -241,6 +270,7 @@ Flags:
       --subdomains strings      A list of subdomain names to test during discovery
       --threads int             Number of parallel threads to use for discovery (default 10)
       --timeout int             Maximum time (in minutes) to spend on subdomain discovery
+      --wildcard-checks int     Number of random subdomain probes used to detect wildcard DNS records (default 3)
       --wordlist-file string    The file containing the wordlist to use for discovery
       --wordlist-size string    The size of the in-built wordlist to use for discovery
 
@@ -299,12 +329,13 @@ Usage:
 
 Flags:
       --all-sources               Use all passive sources (subfinder equivalent of --all)
-      --dns-resolvers strings     Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53) (default [1.1.1.1:53])
+      --dns-resolvers strings     Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)
       --domain string             The domain name to passively enumerate subdomains for
   -h, --help                      help for passive
       --max-dns-queries int       Maximum number of DNS queries to perform per request (default 2000)
       --max-resolvers-qps int     Maximum number of queries per second per resolver (default 100)
       --modules strings           Which passive modules to run: SUBFINDER, AMASS, or ALL (default [SUBFINDER])
+      --recursive-depth int       Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.)
       --requests-per-second int   Maximum number of requests per second to send to the DNS resolvers
       --threads int               Number of concurrent threads for scanning (default 10)
 
@@ -338,7 +369,7 @@ Usage:
 
 Flags:
       --cidr string             The CIDR range to perform reverse DNS and ASN lookup on
-      --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53) (default [1.1.1.1:53])
+      --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)
   -h, --help                    help for domain-asn
       --ip-addresses strings    The IP addresses to perform reverse DNS and ASN lookup on
 

--- a/docs/docs/enumerate.md
+++ b/docs/docs/enumerate.md
@@ -23,23 +23,23 @@ Attempt DNS zone transfers (AXFR) to enumerate all DNS records if the server all
 
 ##### Usage
 ```bash
-osintscan enumerate dns zonetransfer --domains example.com
-osintscan enumerate dns zonetransfer --nameserver ns1.example.com
+osintscan enumerate dns zone-transfer --zones example.com
+osintscan enumerate dns zone-transfer --zones example.com --target-nameservers 10.0.0.1
 ```
 
 ##### Help Text
 ```bash
-Attempt DNS zone transfers (AXFR) for the specified domains to enumerate all DNS records, if the server allows it. This can reveal all subdomains and records
+Attempt DNS zone transfers (AXFR) for the specified zones to enumerate all DNS records, if the server allows it. This can reveal all subdomains and records
 
 Usage:
-  osintscan enumerate dns zonetransfer [domain...] [flags]
+  osintscan enumerate dns zone-transfer [flags]
 
 Flags:
-      --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53) (default [1.1.1.1:53])
-      --domains strings         A list of domain names to attempt zone transfers on
-  -h, --help                    help for zonetransfer
-      --nameserver string       Specific nameserver to test zone transfers against (e.g., ns1.example.com or 192.168.1.10)
-      --timeout int             Timeout in seconds for each zone transfer request (default 30)
+      --dns-resolvers strings       DNS resolvers for NS lookups (e.g. 10.0.0.1). Uses system resolver if not set.
+  -h, --help                        help for zone-transfer
+      --target-nameservers strings  Nameserver IPs to attempt AXFR against directly, bypassing NS record lookup (e.g. 10.0.0.1)
+      --timeout int                 Timeout in seconds for each zone transfer request (default 30)
+      --zones strings               Zone FQDNs to test for unauthorized zone transfers (e.g. example.com)
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")

--- a/docs/docs/pentest.md
+++ b/docs/docs/pentest.md
@@ -34,7 +34,7 @@ Usage:
   osintscan pentest dns takeover [flags]
 
 Flags:
-      --fingerprints-file string   Path to the JSON file containing service fingerprints for takeover detection (default "/opt/method/osintscan/var/conf/pentest/dns/takeover/fingerprints.json")
+      --fingerprints-file string   Path to the JSON file containing service fingerprints for takeover detection
   -h, --help                       help for takeover
       --successful-only            Show only confirmed successful takeovers in the results
       --target-files strings       File paths containing lists of targets to analyze for takeover vulnerabilities

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: osintscan
 site_url: https://method-security.github.io/osintscan/
-site_description: AWS enumeration capabilities for security teams of all sizes
+site_description: OSINT capabilities for security teams of all sizes
 docs_dir: docs/
 repo_name: GitHub
 repo_url: https://github.com/Method-Security/osintscan


### PR DESCRIPTION
## Summary

- **enumerate.md**: Fix zone-transfer command — correct name (`zone-transfer` not `zonetransfer`), correct flags (`--zones` not `--domains`, `--target-nameservers` not `--nameserver`), remove false dns-resolvers default
- **discover.md**: Add missing `idp` command section; fix `--fingerprints-file` default (no hardcoded path); add `--wildcard-checks` flag to active subdomain; add `--recursive-depth` flag to passive subdomain; remove incorrect `(default [1.1.1.1:53])` from all `--dns-resolvers` flags
- **pentest.md**: Remove hardcoded default path from `--fingerprints-file`

## Test plan

- [x] `mkdocs build --strict` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes, but incorrect command/flag docs could still mislead users if not aligned with the actual CLI behavior.
> 
> **Overview**
> Updates the capability docs to match current CLI behavior and remove misleading defaults. `discover.md` adds a full `idp` command section (Azure AD/Entra ID + Okta detection) and corrects several flags/help-text details (e.g., removing hardcoded default paths and `dns-resolvers` defaults, documenting `--wildcard-checks` and `--recursive-depth`).
> 
> `enumerate.md` fixes the DNS zone transfer command/flags to `zone-transfer` with `--zones` and `--target-nameservers`. `pentest.md` removes the hardcoded default for `--fingerprints-file`, and `mkdocs.yml` updates the site description to OSINT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb94aab107037f95fe501b9bb89b2efc956e55c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->