### PR TITLE
Fix wildcard CNAME subdomain filtering

### DIFF
--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -59,25 +60,21 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 	}
 	resolvers := utils.GetResolvers(dnsServerAddresses, log)
 
-	// Build normalized server addresses for raw DNS queries (CNAME lookups).
-	rawResolvers := make([]string, len(dnsServerAddresses))
-	for i, addr := range dnsServerAddresses {
-		rawResolvers[i] = utils.NormalizeDNSAddress(addr)
-	}
+	rawResolvers := normalizeRawResolvers(dnsServerAddresses)
 
 	// First iteration - test base domain for wildcards (A/AAAA and CNAME)
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
-	wildcardFound, wildcardA, err := detectWildcardDNS(ctx, domain, resolvers[0], wildcardChecks, rawResolvers[0])
+	wildcardProfile, err := detectWildcardDNSProfile(ctx, domain, resolvers[0], wildcardChecks, rawResolvers[0])
 	if err != nil {
 		return []string{}, err
 	}
-	if wildcardA {
+	if wildcardProfile.HasAddresses() {
 		log.Info("Wildcard DNS detected, skipping brute force", svc1log.SafeParam("wildcard", "*."+domain))
 		return subdomains, nil
 	}
-	wildcardCNAMEDomains := map[string]struct{}{}
-	if wildcardFound && !wildcardA {
-		wildcardCNAMEDomains[domain] = struct{}{}
+	wildcardCNAMEDomains := map[string]map[string]struct{}{}
+	if wildcardProfile.HasCNAMETargets() {
+		wildcardCNAMEDomains[domain] = wildcardProfile.CNAMETargets
 		log.Info("Wildcard CNAME detected, disabling CNAME fallback", svc1log.SafeParam("domain", domain))
 	}
 
@@ -101,20 +98,20 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 			svc1log.SafeParam("subdomain_count", len(currentDepthSubdomains)))
 
 		validSubdomains := []string{}
-		depthWildcardCNAMEDomains := map[string]struct{}{}
+		depthWildcardCNAMEDomains := map[string]map[string]struct{}{}
 		for _, subdomain := range currentDepthSubdomains {
-			depthWildcardFound, depthWildcardA, err := detectWildcardDNS(ctx, subdomain, resolvers[0], wildcardChecks, rawResolvers[0])
+			depthWildcardProfile, err := detectWildcardDNSProfile(ctx, subdomain, resolvers[0], wildcardChecks, rawResolvers[0])
 			if err != nil {
 				continue
 			}
-			if depthWildcardA {
+			if depthWildcardProfile.HasAddresses() {
 				log.Info("Wildcard DNS detected for subdomain, skipping",
 					svc1log.SafeParam("subdomain", subdomain),
 					svc1log.SafeParam("wildcard", "*."+subdomain))
 				continue
 			}
-			if depthWildcardFound && !depthWildcardA {
-				depthWildcardCNAMEDomains[subdomain] = struct{}{}
+			if depthWildcardProfile.HasCNAMETargets() {
+				depthWildcardCNAMEDomains[subdomain] = depthWildcardProfile.CNAMETargets
 				log.Info("Wildcard CNAME detected for subdomain, disabling CNAME fallback",
 					svc1log.SafeParam("subdomain", subdomain),
 					svc1log.SafeParam("wildcard_cname", "*."+subdomain))
@@ -126,12 +123,13 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		currentDepthSubdomains = testPermutations(ctx, newPermutations, resolvers, semaphore, &wg, subdomainsMutex, subdomainsSet, &subdomains, depth, recursiveDepth, sleep, rawResolvers, depthWildcardCNAMEDomains)
 	}
 
+	sort.Strings(subdomains)
 	return subdomains, nil
 }
 
 // testPermutations concurrently tests a list of subdomain permutations for DNS resolution.
 // Uses a semaphore to limit concurrency and mutexes to protect shared state.
-func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int, rawResolvers []string, wildcardCNAMEDomains map[string]struct{}) []string {
+func testPermutations(ctx context.Context, permutations []string, resolvers []*net.Resolver, semaphore chan struct{}, wg *sync.WaitGroup, subdomainsMutex *sync.Mutex, subdomainsSet map[string]struct{}, subdomains *[]string, depth int, maxDepth int, sleep int, rawResolvers []string, wildcardCNAMEDomains map[string]map[string]struct{}) []string {
 	log := svc1log.FromContext(ctx)
 	var validSubdomains []string
 	validSubdomainsMutex := &sync.Mutex{}
@@ -162,10 +160,22 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			// Round robin CNAME server selection (may differ in length from resolvers
 			// when system defaults are used)
 			rawResolverIdx := currentIndex % int64(len(rawResolvers))
+			rawResolver := rawResolvers[rawResolverIdx]
+			wildcardCNAMETargets := getParentWildcardCNAMETargets(testSubdomain, wildcardCNAMEDomains)
 
 			// Capture the duration of the lookup
 			start := time.Now()
 			_, err := resolver.LookupHost(ctx, testSubdomain)
+			if err == nil && len(wildcardCNAMETargets) > 0 && rawResolver != "" {
+				if cnameTargetsMatch(lookupCNAMEs(testSubdomain, rawResolver), wildcardCNAMETargets) {
+					duration := time.Since(start)
+					log.Info("Skipping wildcard CNAME match",
+						svc1log.SafeParam("subdomain", testSubdomain),
+						svc1log.SafeParam("duration_ms", duration.Milliseconds()),
+						svc1log.SafeParam("depth", depth))
+					return
+				}
+			}
 			// If LookupHost fails (no A/AAAA record), check for CNAME records
 			// via a raw DNS query. Go's net.LookupCNAME follows the CNAME chain
 			// and fails if the target doesn't resolve, so it can't detect dangling
@@ -174,15 +184,17 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			// Only attempt CNAME detection on a definitive NXDOMAIN — SERVFAIL,
 			// timeouts, and other transient errors must not trigger the CNAME path.
 			if err != nil && isDNSNotFound(err) {
-				// Extract parent domain to check if it has a wildcard CNAME
-				parentHasWildcardCNAME := false
-				if parts := strings.SplitN(testSubdomain, ".", 2); len(parts) == 2 {
-					_, parentHasWildcardCNAME = wildcardCNAMEDomains[parts[1]]
-				}
-				if !parentHasWildcardCNAME {
-					if hasCNAME(testSubdomain, rawResolvers[rawResolverIdx]) {
-						err = nil
+				cnameTargets := lookupCNAMEs(testSubdomain, rawResolver)
+				if len(cnameTargets) > 0 {
+					if len(wildcardCNAMETargets) > 0 && cnameTargetsMatch(cnameTargets, wildcardCNAMETargets) {
+						duration := time.Since(start)
+						log.Info("Skipping wildcard CNAME match",
+							svc1log.SafeParam("subdomain", testSubdomain),
+							svc1log.SafeParam("duration_ms", duration.Milliseconds()),
+							svc1log.SafeParam("depth", depth))
+						return
 					}
+					err = nil
 				}
 			}
 			duration := time.Since(start)
@@ -231,26 +243,60 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 	return validSubdomains
 }
 
-// hasCNAME performs a raw DNS CNAME query to detect CNAME records, including dangling
-// ones where the target doesn't resolve. Go's net.LookupCNAME follows the chain and
-// fails on dangling CNAMEs, so we use miekg/dns for a single-hop raw query instead.
-// The server parameter must be a normalized address with port (e.g. "1.1.1.1:53").
-func hasCNAME(subdomain string, server string) bool {
+func lookupCNAMEs(subdomain string, server string) []string {
+	if server == "" {
+		return nil
+	}
+
 	msg := new(dns.Msg)
 	msg.SetQuestion(dns.Fqdn(subdomain), dns.TypeCNAME)
 	msg.RecursionDesired = true
 
-	resp, err := dns.Exchange(msg, server)
+	client := &dns.Client{Timeout: 5 * time.Second}
+	resp, _, err := client.Exchange(msg, server)
 	if err != nil || resp == nil {
-		return false
+		return nil
 	}
 
+	targets := []string{}
 	for _, ans := range resp.Answer {
-		if _, ok := ans.(*dns.CNAME); ok {
+		if cname, ok := ans.(*dns.CNAME); ok {
+			targets = append(targets, normalizeDNSName(cname.Target))
+		}
+	}
+	return targets
+}
+
+func getParentWildcardCNAMETargets(subdomain string, wildcardCNAMEDomains map[string]map[string]struct{}) map[string]struct{} {
+	if parts := strings.SplitN(subdomain, ".", 2); len(parts) == 2 {
+		return wildcardCNAMEDomains[parts[1]]
+	}
+	return nil
+}
+
+func cnameTargetsMatch(targets []string, wildcardTargets map[string]struct{}) bool {
+	for _, target := range targets {
+		if _, ok := wildcardTargets[normalizeDNSName(target)]; ok {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeDNSName(name string) string {
+	return strings.TrimSuffix(strings.ToLower(name), ".")
+}
+
+func normalizeRawResolvers(dnsServerAddresses []string) []string {
+	if len(dnsServerAddresses) == 0 {
+		return []string{""}
+	}
+
+	rawResolvers := make([]string, len(dnsServerAddresses))
+	for i, addr := range dnsServerAddresses {
+		rawResolvers[i] = utils.NormalizeDNSAddress(addr)
+	}
+	return rawResolvers
 }
 
 // generatePermutations creates all possible subdomain permutations for the given base subdomains and subdomain list.

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -9,35 +9,73 @@ import (
 	"net"
 )
 
+type wildcardDNSProfile struct {
+	Addresses    map[string]struct{}
+	CNAMETargets map[string]struct{}
+}
+
+func newWildcardDNSProfile() wildcardDNSProfile {
+	return wildcardDNSProfile{
+		Addresses:    map[string]struct{}{},
+		CNAMETargets: map[string]struct{}{},
+	}
+}
+
+func (p wildcardDNSProfile) HasAddresses() bool {
+	return len(p.Addresses) > 0
+}
+
+func (p wildcardDNSProfile) HasCNAMETargets() bool {
+	return len(p.CNAMETargets) > 0
+}
+
 // detectWildcardDNS tests multiple random high-entropy subdomains to check if a wildcard DNS record is present.
 // Checks both A/AAAA records (via LookupHost) and CNAME records (via raw query) since a dangling
 // wildcard CNAME won't resolve via LookupHost but still produces false positives in brute-force.
 // Returns (true, true) for A/AAAA wildcard, (true, false) for CNAME-only wildcard, (false, false) for no wildcard.
 func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolver, wildcardChecks int, rawResolver string) (wildcardFound bool, wildcardA bool, err error) {
+	profile, err := detectWildcardDNSProfile(ctx, domain, resolver, wildcardChecks, rawResolver)
+	if err != nil {
+		return false, false, err
+	}
+	return profile.HasAddresses() || profile.HasCNAMETargets(), profile.HasAddresses(), nil
+}
+
+func detectWildcardDNSProfile(ctx context.Context, domain string, resolver *net.Resolver, wildcardChecks int, rawResolver string) (wildcardDNSProfile, error) {
+	profile := newWildcardDNSProfile()
 	for i := 0; i < wildcardChecks; i++ {
 		randomSubdomain, err := generateRandomSubdomain(domain)
 		if err != nil {
-			return false, false, err
+			return profile, err
 		}
 
-		_, err = resolver.LookupHost(ctx, randomSubdomain)
+		addresses, err := resolver.LookupHost(ctx, randomSubdomain)
 		if err == nil {
 			// Random subdomain resolved via A/AAAA - wildcard is present
-			return true, true, nil
+			for _, address := range addresses {
+				profile.Addresses[address] = struct{}{}
+			}
+			for _, target := range lookupCNAMEs(randomSubdomain, rawResolver) {
+				profile.CNAMETargets[target] = struct{}{}
+			}
+			return profile, nil
 		}
 
 		if !isDNSNotFound(err) {
 			// Non-NXDOMAIN error (timeout, SERVFAIL, etc.) - DNS is unreliable
-			return false, false, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
+			return profile, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
 		}
 
 		// NXDOMAIN for A/AAAA - check if a wildcard CNAME exists (only when a raw resolver is provided)
-		if rawResolver != "" && hasCNAME(randomSubdomain, rawResolver) {
-			return true, false, nil
+		for _, target := range lookupCNAMEs(randomSubdomain, rawResolver) {
+			profile.CNAMETargets[target] = struct{}{}
+		}
+		if profile.HasCNAMETargets() {
+			return profile, nil
 		}
 	}
 
-	return false, false, nil
+	return profile, nil
 }
 
 // generateRandomSubdomain generates a high-entropy subdomain with only letters (16 characters).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core active DNS brute-force logic by tracking wildcard CNAME targets and filtering matches, which can alter discovered subdomains and risk false negatives/positives if DNS parsing or matching is off.
> 
> **Overview**
> Improves active subdomain discovery’s wildcard handling by replacing the boolean wildcard CNAME flag with a *wildcard profile* that records resolved A/AAAA addresses and observed CNAME targets, and uses those targets to filter out wildcard-derived results during brute force.
> 
> Adds raw CNAME lookups that return normalized target lists (with an explicit DNS client timeout), matches discovered CNAME targets against the parent domain’s wildcard targets (including when `LookupHost` succeeds), and makes raw resolver normalization safer when no resolvers are configured. Discovered subdomains are now sorted before returning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238eca4755e62b2dd852aed8393552c4b72c1bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->