### PR TITLE
Standardize AWS CDN Type ENUM

### DIFF
--- a/fern/definition/discover/cdn/cdn.yml
+++ b/fern/definition/discover/cdn/cdn.yml
@@ -3,7 +3,6 @@ types:
   CdnProvider:
     enum:
     - AKAMAI
-    - AWS
     - AZURE_FRONTDOOR
     - CLOUDFLARE
     - CLOUDFRONT

--- a/internal/discover/cdn.go
+++ b/internal/discover/cdn.go
@@ -22,14 +22,18 @@ import (
 	"github.com/Method-Security/osintscan/utils"
 )
 
-// cdncheckProviderMap maps the lowercase provider name strings returned by cdncheck
-// to their corresponding Fern CdnProvider enum key strings.
-// Note: "amazon" is the CNAME-based name cdncheck uses for Amazon CloudFront.
+// cdncheckProviderMap maps the lowercase provider name strings returned by
+// cdncheck's IP-based Check (CDN/WAF/Cloud categories) to their corresponding
+// Fern CdnProvider enum key strings.
+//
+// Note: cdncheck's Cloud category returns "aws" for Amazon-owned IP ranges,
+// which include CloudFront's edge IPs as well as the broader AWS network. We
+// map "aws" to CLOUDFRONT so AWS-resolved CDN matches are reported under the
+// CloudFront provider.
 // Note: "imperva" is the parent company of Incapsula and maps to INCAPSULA.
 var cdncheckProviderMap = map[string]string{
 	"akamai":     "AKAMAI",
-	"amazon":     "CLOUDFRONT",
-	"aws":        "AWS",
+	"aws":        "CLOUDFRONT",
 	"cloudflare": "CLOUDFLARE",
 	"cloudfront": "CLOUDFRONT",
 	"edgecast":   "EDGECAST",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the reported CDN provider for cdncheck matches from `AWS`/`amazon` to `CLOUDFRONT`, which may affect downstream consumers expecting the old enum value.
> 
> **Overview**
> Standardizes AWS-related CDN reporting by **removing `AWS` from the `CdnProvider` enum** and updating discovery mapping so cdncheck’s `"aws"` detections are emitted as `CLOUDFRONT`.
> 
> Updates the inline documentation in `internal/discover/cdn.go` to clarify that cdncheck’s IP-based Cloud category returns `aws` for Amazon-owned ranges and why those results are treated as CloudFront.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a9b8d34c549e00efdc0df18950cf90ecffad814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->