### PR TITLE
Update Error Msg in CDN Check

### DIFF
--- a/internal/discover/cdn.go
+++ b/internal/discover/cdn.go
@@ -4,6 +4,7 @@ import (
 	// Standard
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -118,8 +119,23 @@ func RunDiscoverCdns(ctx context.Context, config cdnfern.DiscoverCdnConfig) *cdn
 func resolveDomain(ctx context.Context, domain string, dnsResolvers []string) ([]string, error) {
 	log := svc1log.FromContext(ctx)
 	resolvers := utils.GetResolvers(dnsResolvers, log)
-	resolver := resolvers[rand.Intn(len(resolvers))]
-	return resolver.LookupHost(ctx, domain)
+	resolverIndex := rand.Intn(len(resolvers))
+	resolver := resolvers[resolverIndex]
+
+	resolverAddress := "system default resolver"
+	if len(dnsResolvers) > 0 {
+		resolverAddress = utils.NormalizeDNSAddress(dnsResolvers[resolverIndex])
+	}
+
+	ips, err := resolver.LookupHost(ctx, domain)
+	if err != nil {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) {
+			return nil, fmt.Errorf("lookup using %s failed for %s: %s", resolverAddress, domain, dnsErr.Err)
+		}
+		return nil, fmt.Errorf("lookup using %s failed for %s: %v", resolverAddress, domain, err)
+	}
+	return ips, nil
 }
 
 // checkSupplemental checks an IP against the supplemental provider CIDR ranges.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes error formatting and adds resolver context when `LookupHost` fails, with no behavior changes on successful resolution.
> 
> **Overview**
> **CDN domain resolution now returns more actionable errors.** `resolveDomain` tracks which randomly-selected DNS resolver was used (or notes the system default) and wraps `LookupHost` failures with that resolver address.
> 
> For `net.DNSError`, the error message is simplified to the underlying DNS error string; all other errors are still surfaced with full details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41ca229ec4e6ce1ec764cb59d7cb75d9cef550a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->