### PR TITLE
Update Active Sub-Domain Command to be more protective to DNS Failures

### DIFF
--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -61,10 +61,11 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 	resolvers := utils.GetResolvers(dnsServerAddresses, log)
 
 	rawResolvers := normalizeRawResolvers(dnsServerAddresses)
+	wildcardProfileCache := map[string]wildcardDNSProfile{}
 
 	// First iteration - test base domain for wildcards (A/AAAA and CNAME)
 	log.Info("Detecting wildcards", svc1log.SafeParam("domain", domain))
-	wildcardProfile, err := detectWildcardDNSProfile(ctx, domain, resolvers[0], wildcardChecks, rawResolvers[0])
+	wildcardProfile, err := detectWildcardDNSProfileCached(ctx, domain, resolvers, wildcardChecks, rawResolvers, wildcardProfileCache)
 	if err != nil {
 		return []string{}, err
 	}
@@ -100,8 +101,12 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 		validSubdomains := []string{}
 		depthWildcardCNAMEDomains := map[string]map[string]struct{}{}
 		for _, subdomain := range currentDepthSubdomains {
-			depthWildcardProfile, err := detectWildcardDNSProfile(ctx, subdomain, resolvers[0], wildcardChecks, rawResolvers[0])
+			depthWildcardProfile, err := detectWildcardDNSProfileCached(ctx, subdomain, resolvers, wildcardChecks, rawResolvers, wildcardProfileCache)
 			if err != nil {
+				log.Warn("Skipping recursive subdomain after wildcard detection failure",
+					svc1log.SafeParam("subdomain", subdomain),
+					svc1log.SafeParam("depth", depth),
+					svc1log.SafeParam("error", err.Error()))
 				continue
 			}
 			if depthWildcardProfile.HasAddresses() {
@@ -125,6 +130,21 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 
 	sort.Strings(subdomains)
 	return subdomains, nil
+}
+
+func detectWildcardDNSProfileCached(ctx context.Context, domain string, resolvers []*net.Resolver, wildcardChecks int, rawResolvers []string, wildcardProfileCache map[string]wildcardDNSProfile) (wildcardDNSProfile, error) {
+	if profile, ok := wildcardProfileCache[domain]; ok {
+		return profile, nil
+	}
+
+	profile, err := detectWildcardDNSProfileWithResolvers(ctx, domain, resolvers, wildcardChecks, rawResolvers)
+	if err != nil {
+		return profile, err
+	}
+	if profile.HasAddresses() || profile.HasCNAMETargets() {
+		wildcardProfileCache[domain] = profile
+	}
+	return profile, nil
 }
 
 // testPermutations concurrently tests a list of subdomain permutations for DNS resolution.
@@ -155,7 +175,6 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			currentIndex := atomic.AddInt64(&resolverIndex, 1) - 1
 			resolverIdx := currentIndex % int64(len(resolvers))
 			resolver := resolvers[resolverIdx]
-			log.Info("Using resolver", svc1log.SafeParam("resolver_index", resolverIdx))
 
 			// Round robin CNAME server selection (may differ in length from resolvers
 			// when system defaults are used)
@@ -207,11 +226,14 @@ func testPermutations(ctx context.Context, permutations []string, resolvers []*n
 			completed := atomic.AddInt64(&completedCount, 1)
 
 			if duration.Milliseconds() < 1000 {
-				log.Info("Subdomain check",
-					svc1log.SafeParam("duration_ms", duration.Milliseconds()),
-					svc1log.SafeParam("depth", depth),
-					svc1log.SafeParam("completed", completed),
-					svc1log.SafeParam("total", totalPermutations))
+				shouldLogProgress := completed%500 == 0 || int(completed) == totalPermutations
+				if shouldLogProgress {
+					log.Info("Subdomain check",
+						svc1log.SafeParam("duration_ms", duration.Milliseconds()),
+						svc1log.SafeParam("depth", depth),
+						svc1log.SafeParam("completed", completed),
+						svc1log.SafeParam("total", totalPermutations))
+				}
 			} else {
 				log.Warn("Subdomain check (Longer than 1 second)",
 					svc1log.SafeParam("duration_ms", duration.Milliseconds()),
@@ -252,8 +274,7 @@ func lookupCNAMEs(subdomain string, server string) []string {
 	msg.SetQuestion(dns.Fqdn(subdomain), dns.TypeCNAME)
 	msg.RecursionDesired = true
 
-	client := &dns.Client{Timeout: 5 * time.Second}
-	resp, _, err := client.Exchange(msg, server)
+	resp, err := exchangeDNSWithFallback(msg, server)
 	if err != nil || resp == nil {
 		return nil
 	}
@@ -265,6 +286,24 @@ func lookupCNAMEs(subdomain string, server string) []string {
 		}
 	}
 	return targets
+}
+
+func exchangeDNSWithFallback(msg *dns.Msg, server string) (*dns.Msg, error) {
+	udpClient := &dns.Client{Net: "udp", Timeout: 5 * time.Second}
+	resp, _, err := udpClient.Exchange(msg, server)
+	if err == nil && resp != nil && !resp.Truncated {
+		return resp, nil
+	}
+
+	tcpClient := &dns.Client{Net: "tcp", Timeout: 5 * time.Second}
+	tcpResp, _, tcpErr := tcpClient.Exchange(msg, server)
+	if tcpErr == nil {
+		return tcpResp, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func getParentWildcardCNAMETargets(subdomain string, wildcardCNAMEDomains map[string]map[string]struct{}) map[string]struct{} {

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -133,7 +133,12 @@ func getSubdomainsActive(ctx context.Context, domain string, subdomainList []str
 }
 
 func detectWildcardDNSProfileCached(ctx context.Context, domain string, resolvers []*net.Resolver, wildcardChecks int, rawResolvers []string, wildcardProfileCache map[string]wildcardDNSProfile) (wildcardDNSProfile, error) {
+	log := svc1log.FromContext(ctx)
 	if profile, ok := wildcardProfileCache[domain]; ok {
+		log.Info("Using cached wildcard DNS profile",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("has_addresses", profile.HasAddresses()),
+			svc1log.SafeParam("has_cname_targets", profile.HasCNAMETargets()))
 		return profile, nil
 	}
 
@@ -143,6 +148,10 @@ func detectWildcardDNSProfileCached(ctx context.Context, domain string, resolver
 	}
 	if profile.HasAddresses() || profile.HasCNAMETargets() {
 		wildcardProfileCache[domain] = profile
+		log.Info("Cached wildcard DNS profile",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("has_addresses", profile.HasAddresses()),
+			svc1log.SafeParam("has_cname_targets", profile.HasCNAMETargets()))
 	}
 	return profile, nil
 }

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"time"
 )
+
+const wildcardProbeDelay = 5 * time.Second
 
 type wildcardDNSProfile struct {
 	Addresses    map[string]struct{}
@@ -42,11 +45,28 @@ func detectWildcardDNS(ctx context.Context, domain string, resolver *net.Resolve
 }
 
 func detectWildcardDNSProfile(ctx context.Context, domain string, resolver *net.Resolver, wildcardChecks int, rawResolver string) (wildcardDNSProfile, error) {
+	return detectWildcardDNSProfileWithResolvers(ctx, domain, []*net.Resolver{resolver}, wildcardChecks, []string{rawResolver})
+}
+
+func detectWildcardDNSProfileWithResolvers(ctx context.Context, domain string, resolvers []*net.Resolver, wildcardChecks int, rawResolvers []string) (wildcardDNSProfile, error) {
 	profile := newWildcardDNSProfile()
+	if wildcardChecks <= 0 || len(resolvers) == 0 {
+		return profile, nil
+	}
+
+	var firstTransientErr error
+	nxdomainCount := 0
+
 	for i := 0; i < wildcardChecks; i++ {
 		randomSubdomain, err := generateRandomSubdomain(domain)
 		if err != nil {
 			return profile, err
+		}
+
+		resolver := resolvers[i%len(resolvers)]
+		rawResolver := ""
+		if len(rawResolvers) > 0 {
+			rawResolver = rawResolvers[i%len(rawResolvers)]
 		}
 
 		addresses, err := resolver.LookupHost(ctx, randomSubdomain)
@@ -62,9 +82,23 @@ func detectWildcardDNSProfile(ctx context.Context, domain string, resolver *net.
 		}
 
 		if !isDNSNotFound(err) {
-			// Non-NXDOMAIN error (timeout, SERVFAIL, etc.) - DNS is unreliable
-			return profile, fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
+			// Non-NXDOMAIN errors (timeouts, SERVFAIL, etc.) are common when
+			// resolvers are under load. Keep probing so one bad packet does not
+			// disable wildcard detection.
+			if firstTransientErr == nil {
+				firstTransientErr = fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
+			}
+			if i < wildcardChecks-1 {
+				select {
+				case <-time.After(wildcardProbeDelay):
+				case <-ctx.Done():
+					return profile, ctx.Err()
+				}
+			}
+			continue
 		}
+
+		nxdomainCount++
 
 		// NXDOMAIN for A/AAAA - check if a wildcard CNAME exists (only when a raw resolver is provided)
 		for _, target := range lookupCNAMEs(randomSubdomain, rawResolver) {
@@ -73,8 +107,22 @@ func detectWildcardDNSProfile(ctx context.Context, domain string, resolver *net.
 		if profile.HasCNAMETargets() {
 			return profile, nil
 		}
+
+		if i < wildcardChecks-1 {
+			select {
+			case <-time.After(wildcardProbeDelay):
+			case <-ctx.Done():
+				return profile, ctx.Err()
+			}
+		}
 	}
 
+	if nxdomainCount > 0 {
+		return profile, nil
+	}
+	if firstTransientErr != nil {
+		return profile, firstTransientErr
+	}
 	return profile, nil
 }
 

--- a/internal/discover/dns/subdomain/helpers.go
+++ b/internal/discover/dns/subdomain/helpers.go
@@ -7,7 +7,11 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"sort"
 	"time"
+
+	// External
+	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
 
 const wildcardProbeDelay = 5 * time.Second
@@ -49,10 +53,21 @@ func detectWildcardDNSProfile(ctx context.Context, domain string, resolver *net.
 }
 
 func detectWildcardDNSProfileWithResolvers(ctx context.Context, domain string, resolvers []*net.Resolver, wildcardChecks int, rawResolvers []string) (wildcardDNSProfile, error) {
+	log := svc1log.FromContext(ctx)
 	profile := newWildcardDNSProfile()
 	if wildcardChecks <= 0 || len(resolvers) == 0 {
+		log.Info("Skipping wildcard DNS detection",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("wildcard_checks", wildcardChecks),
+			svc1log.SafeParam("resolver_count", len(resolvers)))
 		return profile, nil
 	}
+
+	log.Info("Starting wildcard DNS detection",
+		svc1log.SafeParam("domain", domain),
+		svc1log.SafeParam("wildcard_checks", wildcardChecks),
+		svc1log.SafeParam("resolver_count", len(resolvers)),
+		svc1log.SafeParam("raw_resolver_count", len(rawResolvers)))
 
 	var firstTransientErr error
 	nxdomainCount := 0
@@ -69,6 +84,14 @@ func detectWildcardDNSProfileWithResolvers(ctx context.Context, domain string, r
 			rawResolver = rawResolvers[i%len(rawResolvers)]
 		}
 
+		log.Info("Running wildcard DNS probe",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("probe", i+1),
+			svc1log.SafeParam("wildcard_checks", wildcardChecks),
+			svc1log.SafeParam("random_subdomain", randomSubdomain),
+			svc1log.SafeParam("resolver_index", i%len(resolvers)),
+			svc1log.SafeParam("raw_resolver", rawResolver))
+
 		addresses, err := resolver.LookupHost(ctx, randomSubdomain)
 		if err == nil {
 			// Random subdomain resolved via A/AAAA - wildcard is present
@@ -78,6 +101,15 @@ func detectWildcardDNSProfileWithResolvers(ctx context.Context, domain string, r
 			for _, target := range lookupCNAMEs(randomSubdomain, rawResolver) {
 				profile.CNAMETargets[target] = struct{}{}
 			}
+			log.Info("Wildcard DNS probe completed",
+				svc1log.SafeParam("domain", domain),
+				svc1log.SafeParam("probe", i+1),
+				svc1log.SafeParam("wildcard_checks", wildcardChecks),
+				svc1log.SafeParam("random_subdomain", randomSubdomain),
+				svc1log.SafeParam("result", "wildcard_detected"),
+				svc1log.SafeParam("record_type", "A/AAAA"),
+				svc1log.SafeParam("addresses", setKeys(profile.Addresses)),
+				svc1log.SafeParam("cname_targets", setKeys(profile.CNAMETargets)))
 			return profile, nil
 		}
 
@@ -88,6 +120,13 @@ func detectWildcardDNSProfileWithResolvers(ctx context.Context, domain string, r
 			if firstTransientErr == nil {
 				firstTransientErr = fmt.Errorf("DNS resolution failed during wildcard detection for %s: %v", randomSubdomain, err)
 			}
+			log.Info("Wildcard DNS probe completed",
+				svc1log.SafeParam("domain", domain),
+				svc1log.SafeParam("random_subdomain", randomSubdomain),
+				svc1log.SafeParam("probe", i+1),
+				svc1log.SafeParam("wildcard_checks", wildcardChecks),
+				svc1log.SafeParam("result", "failure"),
+				svc1log.SafeParam("error", err.Error()))
 			if i < wildcardChecks-1 {
 				select {
 				case <-time.After(wildcardProbeDelay):
@@ -105,8 +144,23 @@ func detectWildcardDNSProfileWithResolvers(ctx context.Context, domain string, r
 			profile.CNAMETargets[target] = struct{}{}
 		}
 		if profile.HasCNAMETargets() {
+			log.Info("Wildcard DNS probe completed",
+				svc1log.SafeParam("domain", domain),
+				svc1log.SafeParam("probe", i+1),
+				svc1log.SafeParam("wildcard_checks", wildcardChecks),
+				svc1log.SafeParam("random_subdomain", randomSubdomain),
+				svc1log.SafeParam("result", "wildcard_detected"),
+				svc1log.SafeParam("record_type", "CNAME"),
+				svc1log.SafeParam("cname_targets", setKeys(profile.CNAMETargets)))
 			return profile, nil
 		}
+
+		log.Info("Wildcard DNS probe completed",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("random_subdomain", randomSubdomain),
+			svc1log.SafeParam("probe", i+1),
+			svc1log.SafeParam("wildcard_checks", wildcardChecks),
+			svc1log.SafeParam("result", "NXDOMAIN"))
 
 		if i < wildcardChecks-1 {
 			select {
@@ -118,12 +172,33 @@ func detectWildcardDNSProfileWithResolvers(ctx context.Context, domain string, r
 	}
 
 	if nxdomainCount > 0 {
+		log.Info("Wildcard DNS not detected",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("nxdomain_count", nxdomainCount),
+			svc1log.SafeParam("wildcard_checks", wildcardChecks))
 		return profile, nil
 	}
 	if firstTransientErr != nil {
+		log.Warn("Wildcard DNS detection failed after transient DNS errors",
+			svc1log.SafeParam("domain", domain),
+			svc1log.SafeParam("wildcard_checks", wildcardChecks),
+			svc1log.SafeParam("error", firstTransientErr.Error()))
 		return profile, firstTransientErr
 	}
+	log.Info("Wildcard DNS not detected",
+		svc1log.SafeParam("domain", domain),
+		svc1log.SafeParam("nxdomain_count", nxdomainCount),
+		svc1log.SafeParam("wildcard_checks", wildcardChecks))
 	return profile, nil
+}
+
+func setKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for value := range values {
+		keys = append(keys, value)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // generateRandomSubdomain generates a high-entropy subdomain with only letters (16 characters).

--- a/utils/resolver.go
+++ b/utils/resolver.go
@@ -55,7 +55,7 @@ func GetResolver(dnsServerAddress string, log svc1log.Logger) *net.Resolver {
 				d := net.Dialer{
 					Timeout: time.Second * 10,
 				}
-				return d.DialContext(ctx, "udp", addr)
+				return d.DialContext(ctx, network, addr)
 			},
 		}
 	}


### PR DESCRIPTION
## Summary

1. Wildcard probes are spaced out and retried In internal/discover/dns/subdomain/helpers.go:46, wildcard detection no longer gives up on the first SERVFAIL/timeout. With --wildcard-checks 3, it can now try up to 9 random wildcard probes, with a 5 second sleep between probes.

2. Wildcard “yes” results are cached, wildcard “no” results are not In internal/discover/dns/subdomain/active.go:128, if *.domain.com is detected, that result is reused. But if a check says “no wildcard,” it is not cached, because that “no” might be caused by transient DNS failure.

3. DNS TCP fallback now actually works. In utils/resolver.go:58, your resolver used to ignore Go’s requested network and always dial UDP. That means TCP fallback could never happen. In Kubernetes/prod, UDP DNS is more likely to be flaky or truncated. Now it honors udp vs cp.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DNS probing behavior (wildcard detection, resolver dialing, and CNAME querying), which can affect scan completeness/performance and introduce new timing/network edge cases. While bounded, added retries/delays and TCP fallback may change runtime characteristics in production environments.
> 
> **Overview**
> Makes active subdomain discovery more resilient to flaky DNS by **retrying wildcard probes across multiple resolvers with a fixed delay** instead of failing fast on transient errors, and by adding structured logging around probe outcomes.
> 
> Adds a small **cache for positive wildcard DNS profiles** (A/AAAA or CNAME) so repeated recursive checks reuse prior wildcard results, and skips deeper recursion when wildcard detection fails.
> 
> Improves DNS querying reliability by adding **UDP-to-TCP fallback** for raw CNAME lookups and fixing `utils.GetResolver` to honor the requested network so TCP fallback can actually occur; also reduces log spam by throttling per-permutation progress logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25bce941a8eb6d1aff06a966f9da6f4b328e407d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->