### PR TITLE
bump to go 1.26.3

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26"
+  GO_VERSION: "1.26.3"
 
 jobs:
   prepare-linux-arm:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version: "1.26.3"
           cache: true
 
       - name: Godel Verify

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # Dockerfile used for the compilation of the statically compiled osintscan binary
-FROM golang:1.26.0-alpine3.22 AS base
+FROM golang:1.26.3-alpine3.22 AS base
 ARG GORELEASER_VERSION="v2.0.1"
 ARG CLI_NAME="osintscan"
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Method-Security/osintscan
 
-go 1.26.0
+go 1.26.3
 
 require (
 	github.com/Method-Security/pkg v0.0.8


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-level toolchain bump only; no application logic or dependency changes beyond the Go version pin.
> 
> **Overview**
> Aligns the project on **Go 1.26.3** everywhere builds and verification run.
> 
> The `go` directive in `go.mod` moves from `1.26.0` to `1.26.3`. CI picks up the same patch: reusable build workflow `GO_VERSION` and verify workflow `setup-go` both use `1.26.3`. The builder image base tag updates from `golang:1.26.0-alpine3.22` to `golang:1.26.3-alpine3.22`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818a5beed09f978d38f0f97fa2ab28b3e09790bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->