### PR TITLE
Align osintscan CLI defaults with golden task

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -176,7 +176,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSRecordsCmd.Flags().String("domain", "", "The domain name to query for DNS records")
 	discoverDNSRecordsCmd.Flags().StringSlice("record-types", []string{"ALL"}, "Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, ALL)")
-	discoverDNSRecordsCmd.Flags().StringSlice("dns-resolvers", []string{}, "DNS resolvers to use for record lookups (e.g. 10.0.0.1:53). Uses public resolvers if not set.")
+	discoverDNSRecordsCmd.Flags().StringSlice("dns-resolvers", []string{}, "DNS resolvers to use for record lookups (e.g. 10.0.0.1:53).")
 
 	// Mark Required Flags
 	_ = discoverDNSRecordsCmd.MarkFlagRequired("domain")
@@ -211,7 +211,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Target Flags
 	discoverDNSForwardCmd.Flags().String("domain", "", "The domain name to perform forward lookups on")
-	discoverDNSForwardCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
+	discoverDNSForwardCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
 
 	// Mark Required Flags
 	_ = discoverDNSForwardCmd.MarkFlagRequired("domain")
@@ -265,8 +265,8 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSReverseCmd.Flags().StringSlice("ip-addresses", []string{}, "The IP addresses to perform reverse DNS lookup on")
 	discoverDNSReverseCmd.Flags().String("cidr", "", "The CIDR range to perform reverse DNS lookup on")
-	discoverDNSReverseCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
-	discoverDNSReverseCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning (Default is number of CPUS on machine)")
+	discoverDNSReverseCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
+	discoverDNSReverseCmd.Flags().Int("threads", 0, "Number of concurrent threads for scanning")
 
 	// Add command to 'dns' command
 	discoverDNSCmd.AddCommand(discoverDNSReverseCmd)
@@ -402,14 +402,14 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 	// Config Flags
 	discoverDNSSubdomainActiveCmd.Flags().StringSlice("subdomains", []string{}, "A list of subdomain names to test during discovery")
-	discoverDNSSubdomainActiveCmd.Flags().String("wordlist-size", "", "The size of the in-built wordlist to use for discovery")
+	discoverDNSSubdomainActiveCmd.Flags().String("wordlist-size", "SMALL", "The size of the in-built wordlist to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().String("wordlist-file", "", "The file containing the wordlist to use for discovery")
-	discoverDNSSubdomainActiveCmd.Flags().Int("threads", 10, "Number of parallel threads to use for discovery")
-	discoverDNSSubdomainActiveCmd.Flags().Int("max-depth", 2, "Maximum recursion depth for subdomain discovery")
-	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 0, "Maximum time (in minutes) to spend on subdomain discovery")
+	discoverDNSSubdomainActiveCmd.Flags().Int("threads", 100, "Number of parallel threads to use for discovery")
+	discoverDNSSubdomainActiveCmd.Flags().Int("max-depth", 1, "Maximum recursion depth for subdomain discovery")
+	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 65, "Maximum time (in minutes) to spend on subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("sleep", 0, "Sleep time in milliseconds between requests to avoid rate limiting")
-	discoverDNSSubdomainActiveCmd.Flags().Int("wildcard-checks", 3, "Number of random subdomain probes used to detect wildcard DNS records")
-	discoverDNSSubdomainActiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
+	discoverDNSSubdomainActiveCmd.Flags().Int("wildcard-checks", 5, "Number of random subdomain probes used to detect wildcard DNS records")
+	discoverDNSSubdomainActiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainActiveCmd.MarkFlagRequired("domain")
@@ -463,7 +463,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainCorrelationCmd.Flags().StringSlice("domains", []string{}, "The domains to test")
 	discoverDNSSubdomainCorrelationCmd.Flags().Int("threads", 10, "Number of parallel threads to use for testing")
 	discoverDNSSubdomainCorrelationCmd.Flags().Int("timeout", 0, "Maximum time (in seconds) to spend on each lookup")
-	discoverDNSSubdomainCorrelationCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
+	discoverDNSSubdomainCorrelationCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainCorrelationCmd.MarkFlagRequired("domains")
@@ -553,13 +553,13 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverDNSSubdomainPassiveCmd.Flags().String("domain", "", "The domain name to passively enumerate subdomains for")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("requests-per-second", 0, "Maximum number of requests per second to send to the DNS resolvers")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 10, "Number of concurrent threads for scanning (defaults to the max which is 10)")
-	discoverDNSSubdomainPassiveCmd.Flags().Bool("all-sources", false, "Use all passive sources (subfinder equivalent of --all)")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("threads", 50, "Number of concurrent threads for scanning")
+	discoverDNSSubdomainPassiveCmd.Flags().Bool("all-sources", true, "Use all passive sources (subfinder equivalent of --all)")
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("modules", []string{"SUBFINDER"}, "Which passive modules to run: SUBFINDER, AMASS, or ALL")
-	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
+	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("max-dns-queries", 2000, "Maximum number of DNS queries to perform per request")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("max-resolvers-qps", 100, "Maximum number of queries per second per resolver")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("recursive-depth", 0, "Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.)")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("max-resolvers-qps", 20, "Maximum number of queries per second per resolver")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("recursive-depth", 1, "Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.)")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainPassiveCmd.MarkFlagRequired("domain")
@@ -620,7 +620,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	}
 
 	// Target Flags
-	discoverShodanHostnameCmd.Flags().String("api-key", "", "Shodan API Key (defaults to SHODAN_API_KEY environment variable if not provided)")
+	discoverShodanHostnameCmd.Flags().String("api-key", "", "Shodan API Key")
 	discoverShodanHostnameCmd.Flags().String("query", "", "The search query string to use with Shodan (e.g., 'apache', 'nginx')")
 	discoverShodanHostnameCmd.Flags().String("hostname", "", "The hostname suffix to match in Shodan search results")
 
@@ -712,7 +712,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverCdnCmd.Flags().String("domain", "", "The domain name to check against CDN provider ranges")
 	discoverCdnCmd.Flags().StringSlice("ip-addresses", []string{}, "IP addresses or CIDRs to check (e.g. 1.2.3.4 or 1.2.3.0/24)")
-	discoverCdnCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
+	discoverCdnCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
 	discoverCdnCmd.Flags().String("fingerprints-file", "", "The path to the CDN fingerprints file")
 
 	// Mark Required Flags
@@ -800,7 +800,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	// Target Flags
 	discoverIPDomainASNCmd.Flags().StringSlice("ip-addresses", []string{}, "The IP addresses to perform reverse DNS and ASN lookup on")
 	discoverIPDomainASNCmd.Flags().String("cidr", "", "The CIDR range to perform reverse DNS and ASN lookup on")
-	discoverIPDomainASNCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1). Uses system resolver if not set.")
+	discoverIPDomainASNCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
 
 	// Add command to 'ip' command
 	discoverIPCmd.AddCommand(discoverIPDomainASNCmd)

--- a/cmd/enumerate.go
+++ b/cmd/enumerate.go
@@ -82,8 +82,8 @@ func (a *OsintScan) InitEnumerateCommand() {
 	enumerateDNSZoneTransferCmd.Flags().StringSlice("zones", []string{}, "Zone FQDNs to test for unauthorized zone transfers (e.g. example.com)")
 
 	// Config Flags
-	enumerateDNSZoneTransferCmd.Flags().Int("timeout", 30, "Timeout in seconds for each zone transfer request")
-	enumerateDNSZoneTransferCmd.Flags().StringSlice("dns-resolvers", []string{}, "DNS resolvers for NS lookups (e.g. 10.0.0.1). Uses system resolver if not set.")
+	enumerateDNSZoneTransferCmd.Flags().Int("timeout", 360, "Timeout in seconds for each zone transfer request")
+	enumerateDNSZoneTransferCmd.Flags().StringSlice("dns-resolvers", []string{}, "DNS resolvers for NS lookups (e.g. 10.0.0.1).")
 	enumerateDNSZoneTransferCmd.Flags().StringSlice("target-nameservers", []string{}, "Nameserver IPs to attempt AXFR against directly, bypassing NS record lookup (e.g. 10.0.0.1)")
 
 	_ = enumerateDNSZoneTransferCmd.MarkFlagRequired("zones")

--- a/cmd/pentest.go
+++ b/cmd/pentest.go
@@ -104,7 +104,7 @@ func (a *OsintScan) InitPentestCommand() {
 	pentestDNSTakeoverCmd.Flags().String("fingerprints-file", "", "Path to the JSON file containing service fingerprints for takeover detection")
 	pentestDNSTakeoverCmd.Flags().Bool("successful-only", false, "Show only confirmed successful takeovers in the results")
 	pentestDNSTakeoverCmd.Flags().Bool("verify-tls", false, "Verify TLS certificates when making HTTPS requests during takeover analysis")
-	pentestDNSTakeoverCmd.Flags().Int("timeout", 30, "Timeout in seconds for each takeover check request")
+	pentestDNSTakeoverCmd.Flags().Int("timeout", 180, "Timeout in seconds for each takeover check request")
 
 	// Mark Required Flags
 	_ = pentestDNSTakeoverCmd.MarkFlagRequired("targets")

--- a/docs/docs/discover.md
+++ b/docs/docs/discover.md
@@ -189,7 +189,7 @@ Usage:
   osintscan discover dns records [flags]
 
 Flags:
-      --dns-resolvers strings   DNS resolvers to use for record lookups (e.g. 10.0.0.1:53). Uses public resolvers if not set.
+      --dns-resolvers strings   DNS resolvers to use for record lookups (e.g. 10.0.0.1:53).
       --domain string           The domain name to query for DNS records
   -h, --help                    help for records
       --record-types strings    Comma-separated list of DNS record types to query (A, AAAA, CNAME, MX, NS, SOA, TXT, PTR, SRV, ALL) (default [ALL])
@@ -251,7 +251,7 @@ Flags:
       --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)
   -h, --help                    help for reverse
       --ip-addresses strings    The IP addresses to perform reverse DNS lookup on
-      --threads int             Number of concurrent threads for scanning (Default is number of CPUS on machine)
+      --threads int             Number of concurrent threads for scanning
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -289,14 +289,14 @@ Flags:
       --dns-resolvers strings   Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)
       --domain string           The domain name to discover subdomains for
   -h, --help                    help for active
-      --max-depth int           Maximum recursion depth for subdomain discovery (default 2)
+      --max-depth int           Maximum recursion depth for subdomain discovery (default 1)
       --sleep int               Sleep time in milliseconds between requests to avoid rate limiting
       --subdomains strings      A list of subdomain names to test during discovery
-      --threads int             Number of parallel threads to use for discovery (default 10)
-      --timeout int             Maximum time (in minutes) to spend on subdomain discovery
-      --wildcard-checks int     Number of random subdomain probes used to detect wildcard DNS records (default 3)
+      --threads int             Number of parallel threads to use for discovery (default 100)
+      --timeout int             Maximum time (in minutes) to spend on subdomain discovery (default 65)
+      --wildcard-checks int     Number of random subdomain probes used to detect wildcard DNS records (default 5)
       --wordlist-file string    The file containing the wordlist to use for discovery
-      --wordlist-size string    The size of the in-built wordlist to use for discovery
+      --wordlist-size string    The size of the in-built wordlist to use for discovery (default "SMALL")
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -352,16 +352,16 @@ Usage:
   osintscan discover dns subdomain passive [flags]
 
 Flags:
-      --all-sources               Use all passive sources (subfinder equivalent of --all)
+      --all-sources               Use all passive sources (subfinder equivalent of --all) (default true)
       --dns-resolvers strings     Custom DNS resolver/servers to use for queries (e.g. 1.1.1.1:53)
       --domain string             The domain name to passively enumerate subdomains for
   -h, --help                      help for passive
       --max-dns-queries int       Maximum number of DNS queries to perform per request (default 2000)
-      --max-resolvers-qps int     Maximum number of queries per second per resolver (default 100)
+      --max-resolvers-qps int     Maximum number of queries per second per resolver (default 20)
       --modules strings           Which passive modules to run: SUBFINDER, AMASS, or ALL (default [SUBFINDER])
-      --recursive-depth int       Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.)
+      --recursive-depth int       Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.) (default 1)
       --requests-per-second int   Maximum number of requests per second to send to the DNS resolvers
-      --threads int               Number of concurrent threads for scanning (default 10)
+      --threads int               Number of concurrent threads for scanning (default 50)
 
 Global Flags:
   -o, --output string        Output format (signal, json, yaml). Default value is signal (default "signal")
@@ -432,7 +432,7 @@ Usage:
   osintscan discover shodan hostname [flags]
 
 Flags:
-      --api-key string    Shodan API Key (defaults to SHODAN_API_KEY environment variable if not provided)
+      --api-key string    Shodan API Key
   -h, --help              help for hostname
       --hostname string   The hostname suffix to match in Shodan search results
       --query string      The search query string to use with Shodan (e.g., 'apache', 'nginx')

--- a/docs/docs/enumerate.md
+++ b/docs/docs/enumerate.md
@@ -35,10 +35,10 @@ Usage:
   osintscan enumerate dns zone-transfer [flags]
 
 Flags:
-      --dns-resolvers strings       DNS resolvers for NS lookups (e.g. 10.0.0.1). Uses system resolver if not set.
+      --dns-resolvers strings       DNS resolvers for NS lookups (e.g. 10.0.0.1).
   -h, --help                        help for zone-transfer
       --target-nameservers strings  Nameserver IPs to attempt AXFR against directly, bypassing NS record lookup (e.g. 10.0.0.1)
-      --timeout int                 Timeout in seconds for each zone transfer request (default 30)
+      --timeout int                 Timeout in seconds for each zone transfer request (default 360)
       --zones strings               Zone FQDNs to test for unauthorized zone transfers (e.g. example.com)
 
 Global Flags:

--- a/docs/docs/pentest.md
+++ b/docs/docs/pentest.md
@@ -39,7 +39,7 @@ Flags:
       --successful-only            Show only confirmed successful takeovers in the results
       --target-files strings       File paths containing lists of targets to analyze for takeover vulnerabilities
       --targets strings            A list of URLs or domains to analyze for takeover vulnerabilities
-      --timeout int                Timeout in seconds for each takeover check request (default 30)
+      --timeout int                Timeout in seconds for each takeover check request (default 180)
       --verify-tls                 Verify TLS certificates when making HTTPS requests during takeover analysis
 
 Global Flags:


### PR DESCRIPTION
## Summary
- align osintscan CLI defaults with golden task parameters
- clean stale default prose from CLI help

## Tests
- go test ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-only changes can increase scan volume, runtime, and external API/DNS load for users who omit flags; no core auth logic changes.
> 
> **Overview**
> This PR **realigns Cobra flag defaults and help text** across `discover`, `enumerate`, and `pentest` so out-of-the-box behavior matches the golden task, and updates the matching docs help blocks.
> 
> **Discover DNS** gets the biggest behavioral shift: **active** subdomain discovery now defaults to a **SMALL** wordlist, **100** threads, **max-depth 1**, **65** minute timeout, and **5** wildcard checks (down from deeper/more conservative defaults). **Passive** enumeration defaults to **all-sources on**, **50** threads, **20** max resolver QPS, and **recursive-depth 1**. **Reverse** DNS drops the “defaults to CPU count” wording for `--threads` (default remains **0** in code). **`--dns-resolvers`** help no longer claims public/system fallbacks when unset.
> 
> **Enumerate** zone-transfer **`--timeout`** rises from **30** to **360** seconds. **Pentest** DNS takeover **`--timeout`** rises from **30** to **180** seconds. Shodan **`--api-key`** help no longer mentions `SHODAN_API_KEY` (runtime still reads the env var).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946dc08b1f6fc5ec731185c20722d5dce981c6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->