### PR TITLE
Fix go-m1cpu darwin arm64 startup crash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,8 @@ require (
 	github.com/rubenv/sql-migrate v1.7.0 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/shirou/gopsutil/v3 v3.24.5 // indirect
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	// Keep >= v0.2.1; v0.1.6 can crash during darwin/arm64 cgo init.
+	github.com/shoenig/go-m1cpu v0.2.1 // indirect
 	github.com/sorairolake/lzip-go v0.3.5 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1430,8 +1430,11 @@ github.com/shirou/gopsutil/v3 v3.24.5 h1:i0t8kL+kQTvpAYToeuiVk3TgDeKOFioZO3Ztz/i
 github.com/shirou/gopsutil/v3 v3.24.5/go.mod h1:bsoOS1aStSs9ErQ1WWfxllSeS1K5D+U30r2NfcubMVk=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
+github.com/shoenig/go-m1cpu v0.2.1 h1:yqRB4fvOge2+FyRXFkXqsyMoqPazv14Yyy+iyccT2E4=
+github.com/shoenig/go-m1cpu v0.2.1/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/vendor/github.com/shoenig/go-m1cpu/.copywrite.hcl
+++ b/vendor/github.com/shoenig/go-m1cpu/.copywrite.hcl
@@ -1,0 +1,12 @@
+schema_version = 1
+
+project {
+  license          = "MPL-2.0"
+  copyright_holder = "The M1CPU Authors"
+  copyright_year   = 2022
+  header_ignore = [
+    ".golangci.yaml",
+    ".copywrite.hcl",
+    ".github/**",
+  ]
+}

--- a/vendor/github.com/shoenig/go-m1cpu/cpu.go
+++ b/vendor/github.com/shoenig/go-m1cpu/cpu.go
@@ -1,3 +1,6 @@
+// Copyright (c) The M1CPU Authors
+// SPDX-License-Identifier: MPL-2.0
+
 //go:build darwin && arm64 && cgo
 
 package m1cpu
@@ -12,10 +15,10 @@ package m1cpu
 // #define kIOMainPortDefault kIOMasterPortDefault
 // #endif
 //
-// #define HzToGHz(hz) ((hz) / 1000000000.0)
+// #define BUFSIZE 512
 //
-// UInt64 global_pCoreHz;
-// UInt64 global_eCoreHz;
+// UInt64 global_pCoreClock;
+// UInt64 global_eCoreClock;
 // int global_pCoreCount;
 // int global_eCoreCount;
 // int global_pCoreL1InstCacheSize;
@@ -27,19 +30,22 @@ package m1cpu
 // char global_brand[32];
 //
 // UInt64 getFrequency(CFTypeRef typeRef) {
-// CFDataRef cfData = typeRef;
+//  if (typeRef == NULL) {
+//    return 0;
+//  }
+//  CFDataRef cfData = typeRef;
 //
-// CFIndex size = CFDataGetLength(cfData);
-// UInt8 buf[size];
-// CFDataGetBytes(cfData, CFRangeMake(0, size), buf);
+//  CFIndex size = CFDataGetLength(cfData);
+//  UInt8 buf[size];
+//  CFDataGetBytes(cfData, CFRangeMake(0, size), buf);
 //
-// UInt8 b1 = buf[size-5];
-// UInt8 b2 = buf[size-6];
-// UInt8 b3 = buf[size-7];
-// UInt8 b4 = buf[size-8];
+//  UInt8 b1 = buf[size-5];
+//  UInt8 b2 = buf[size-6];
+//  UInt8 b3 = buf[size-7];
+//  UInt8 b4 = buf[size-8];
 //
-// UInt64 pCoreHz = 0x00000000FFFFFFFF & ((b1<<24) | (b2 << 16) | (b3 << 8) | (b4));
-// return pCoreHz;
+//  UInt64 pCoreHz = 0x00000000FFFFFFFF & ((b1<<24) | (b2 << 16) | (b3 << 8) | (b4));
+//  return pCoreHz;
 // }
 //
 // int sysctl_int(const char * name) {
@@ -69,42 +75,37 @@ package m1cpu
 //   io_iterator_t  iter;
 //   IOServiceGetMatchingServices(kIOMainPortDefault, matching, &iter);
 //
-//   const size_t bufsize = 512;
 //   io_object_t obj;
 //   while ((obj = IOIteratorNext(iter))) {
-//     char class[bufsize];
+//     char class[BUFSIZE];
 //     IOObjectGetClass(obj, class);
-//     char name[bufsize];
+//     char name[BUFSIZE];
 //     IORegistryEntryGetName(obj, name);
 //
-//     if (strncmp(name, "pmgr", bufsize) == 0) {
-//       CFTypeRef pCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states5-sram"), kCFAllocatorDefault, 0);
-//       CFTypeRef eCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states1-sram"), kCFAllocatorDefault, 0);
+//     if (strncmp(name, "pmgr", BUFSIZE) == 0) {
+//       CFTypeRef pCoreRef = NULL, eCoreRef = NULL;
+//       pCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states5-sram"), kCFAllocatorDefault, 0);
+//       eCoreRef = IORegistryEntryCreateCFProperty(obj, CFSTR("voltage-states1-sram"), kCFAllocatorDefault, 0);
 //
-//       long long pCoreHz = getFrequency(pCoreRef);
-//       long long eCoreHz = getFrequency(eCoreRef);
+//       long long pCoreClock = getFrequency(pCoreRef);
+//       long long eCoreClock = getFrequency(eCoreRef);
 //
-//       global_pCoreHz = pCoreHz;
-//       global_eCoreHz = eCoreHz;
-//       return;
+//       global_pCoreClock = pCoreClock;
+//       global_eCoreClock = eCoreClock;
+//  	 if (pCoreRef) CFRelease(pCoreRef);
+//  	 if (eCoreRef) CFRelease(eCoreRef);
+//		 break;
 //     }
 //   }
+//   IOObjectRelease(iter);
 // }
 //
-// UInt64 eCoreHz() {
-//   return global_eCoreHz;
+// UInt64 eCoreClock() {
+//   return global_eCoreClock;
 // }
 //
-// UInt64 pCoreHz() {
-//   return global_pCoreHz;
-// }
-//
-// Float64 eCoreGHz() {
-//   return HzToGHz(global_eCoreHz);
-// }
-//
-// Float64 pCoreGHz() {
-//   return HzToGHz(global_pCoreHz);
+// UInt64 pCoreClock() {
+//   return global_pCoreClock;
 // }
 //
 // int pCoreCount() {
@@ -143,6 +144,7 @@ package m1cpu
 //   return global_brand;
 // }
 import "C"
+import "fmt"
 
 func init() {
 	C.initialize()
@@ -155,22 +157,22 @@ func IsAppleSilicon() bool {
 
 // PCoreHZ returns the max frequency in Hertz of the P-Core of an Apple Silicon CPU.
 func PCoreHz() uint64 {
-	return uint64(C.pCoreHz())
+	return toHz(uint64(C.pCoreClock()))
 }
 
 // ECoreHZ returns the max frequency in Hertz of the E-Core of an Apple Silicon CPU.
 func ECoreHz() uint64 {
-	return uint64(C.eCoreHz())
+	return toHz(uint64(C.eCoreClock()))
 }
 
 // PCoreGHz returns the max frequency in Gigahertz of the P-Core of an Apple Silicon CPU.
 func PCoreGHz() float64 {
-	return float64(C.pCoreGHz())
+	return toGhz(uint64(C.pCoreClock()))
 }
 
 // ECoreGHz returns the max frequency in Gigahertz of the E-Core of an Apple Silicon CPU.
 func ECoreGHz() float64 {
-	return float64(C.eCoreGHz())
+	return toGhz(uint64(C.eCoreClock()))
 }
 
 // PCoreCount returns the number of physical P (performance) cores.
@@ -210,4 +212,21 @@ func ECoreCache() (int, int, int) {
 // ModelName returns the model name of the CPU.
 func ModelName() string {
 	return C.GoString(C.modelName())
+}
+
+func toHz(hz uint64) uint64 {
+	var gen int
+	// If this errors, fallback to default int value
+	fmt.Sscanf(ModelName(), "Apple M%", &gen)
+
+	// Starting with M4, Apple appears to report clock speed in Khz
+	// See https://github.com/exelban/stats/commit/3e056562b360c937b883725f14f3427d5401b6fe
+	if gen >= 4 {
+		return hz * 1000
+	}
+	return hz
+}
+
+func toGhz(hz uint64) float64 {
+	return float64(toHz(hz) / 1000000000)
 }

--- a/vendor/github.com/shoenig/go-m1cpu/incompatible.go
+++ b/vendor/github.com/shoenig/go-m1cpu/incompatible.go
@@ -1,3 +1,6 @@
+// Copyright (c) The M1CPU Authors
+// SPDX-License-Identifier: MPL-2.0
+
 //go:build !darwin || !arm64 || !cgo
 
 package m1cpu

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -733,7 +733,7 @@ github.com/shirou/gopsutil/v3/internal/common
 github.com/shirou/gopsutil/v3/mem
 github.com/shirou/gopsutil/v3/net
 github.com/shirou/gopsutil/v3/process
-# github.com/shoenig/go-m1cpu v0.1.6
+# github.com/shoenig/go-m1cpu v0.2.1
 ## explicit; go 1.20
 github.com/shoenig/go-m1cpu
 # github.com/sorairolake/lzip-go v0.3.5


### PR DESCRIPTION
Summary:
- Bump github.com/shoenig/go-m1cpu from v0.1.6 to v0.2.1.
- Regenerate the vendored go-m1cpu package.
- Add a go.mod guard comment so this does not regress to the crashing v0.1.6 path.

Tests:
- go build -mod=vendor -o /tmp/osintscan-fix-m1cpu . && /tmp/osintscan-fix-m1cpu version
- go test -mod=vendor ./...

Note:
- fern generate --group local --force --no-prompt passed validation but stalled twice during download; the existing generated bindings on this unchanged base were used for build/test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Indirect dependency and vendor-only update with no app logic changes; lowers crash risk on macOS ARM builds.
> 
> **Overview**
> Fixes **darwin/arm64** startup crashes by upgrading the indirect dependency **`github.com/shoenig/go-m1cpu`** from **v0.1.6** to **v0.2.1** and refreshing **`go.sum`** and **`vendor/`**.
> 
> **`go.mod`** now documents that **v0.1.6** can fail during **cgo** init on Apple Silicon, so the module should stay at **≥ v0.2.1**. The vendored library tightens **IOKit** initialization (null checks, **CFRelease** / **IOObjectRelease**, exit after reading **pmgr** clocks) and adjusts frequency reporting for newer chips (e.g. **M4+** kHz scaling via **`toHz`** / **`toGhz`**).
> 
> No application code in this repo changes; **`gopsutil`** on macOS is what pulls **`go-m1cpu`** in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c158068966dc162e5a66c61dac9e44cf5159b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->