### PR TITLE
Update Default Recurive Depth Value

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -559,7 +559,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainPassiveCmd.Flags().StringSlice("dns-resolvers", []string{}, "Custom DNS resolvers (e.g. 10.0.0.1).")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("max-dns-queries", 2000, "Maximum number of DNS queries to perform per request")
 	discoverDNSSubdomainPassiveCmd.Flags().Int("max-resolvers-qps", 20, "Maximum number of queries per second per resolver")
-	discoverDNSSubdomainPassiveCmd.Flags().Int("recursive-depth", 1, "Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.)")
+	discoverDNSSubdomainPassiveCmd.Flags().Int("recursive-depth", 0, "Recursive discovery depth (0=none, 1=re-scan discovered domains, 2=two levels deep, etc.)")
 
 	// Mark Required Flags
 	_ = discoverDNSSubdomainPassiveCmd.MarkFlagRequired("domain")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single CLI default change; behavior differs only when callers omit `--recursive-depth`, with no auth or data-path impact.
> 
> **Overview**
> Changes the default for **`--recursive-depth`** on **`discover dns subdomain passive`** from **1** to **0**, so passive enumeration no longer re-scans newly discovered hostnames unless the flag is set explicitly.
> 
> This aligns the default with the flag help (`0=none`) and reduces extra passive-source and resolver work on a single-domain run; users who want nested discovery must pass **`--recursive-depth 1`** (or higher).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a250f4e1bcdf4859dc807e75b514a309b2c07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->