### PR TITLE
Kick OSINTScan

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -292,7 +292,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainCmd := &cobra.Command{
 		Use:   "subdomain",
 		Short: "Discover subdomains for a domain",
-		Long:  `Discover subdomains for the specified domain using passive and active enumeration techniques.`,
+		Long:  `Discover subdomains for the specified domain using passive and active enumeration techniques`,
 	}
 
 	discoverDNSCmd.AddCommand(discoverDNSSubdomainCmd)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only CLI help text change with no runtime or discovery behavior impact.
> 
> **Overview**
> Removes the trailing period from the **`Long`** help string on the **`discover dns subdomain`** Cobra command in `cmd/discover.go`. Wording is unchanged; only CLI help punctuation is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2650e66e4c091e75e12a2d7baa59d90b97ec467b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->