### PR TITLE
Forbid extra fields in generated Pydantic models

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -14,6 +14,8 @@ groups:
     generators:
       - name: fernapi/fern-pydantic-model
         version: 1.11.2
+        config:
+          extra_fields: forbid
         output:
           location: local-file-system
           path: ../generated/python
@@ -24,6 +26,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodosintscan
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodosintscan
@@ -36,6 +39,7 @@ groups:
         version: 1.11.2
         config:
           package_name: methodosintscan
+          extra_fields: forbid
         output:
           location: pypi
           package-name: methodosintscan


### PR DESCRIPTION
## Summary

Set `extra_fields: forbid` on every `fern-pydantic-model` generator block (`pypi-local`, `pypi-test`, `pypi`) so the generated config types raise `pydantic.ValidationError` when constructed with unknown kwargs.

## Why

Today the generated models use `extra="allow"`, which silently accepts unknown kwargs and serializes them to the wire payload — that's how `stop_first_success` / `continue_on_error` slipped through the ontology compilers and broke against the v0.0.194 networkscan CLI ("unknown flag" → empty stdout → signal parse failed).

Strict mode (`extra="forbid"`) surfaces the same class of bug at **construction time** in the consumer (ontology compiler / tests), not at runtime on Jackal. Matches https://github.com/method-security/networkscan/pull/331.

## What ships

`generated/python/` is gitignored — CI regenerates from `fern/generators.yml` at publish time, so this single-file change propagates to the next `methodosintscan` wheel automatically.

## Migration note for consumers

After the next wheel publishes, any consumer that still passes unknown kwargs to a generated config will start failing pydantic validation at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional breaking change for consumers that still pass unknown kwargs to generated models after the next published wheel; no runtime service code changes in this repo.
> 
> **Overview**
> Configures all three `fern-pydantic-model` generator targets (`pypi-local`, `pypi-test`, `pypi`) with **`extra_fields: forbid`**, so the next regenerated `methodosintscan` Python models reject unknown kwargs at **Pydantic construction** instead of silently accepting them and sending them on the wire.
> 
> This tightens the contract for ontology compilers and other consumers: misspelled or obsolete config keys (e.g. flags that never existed on the CLI) surface as validation errors during compile/tests rather than failing later at runtime against Jackal/networkscan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c0faea1c77f9ca46a5ec92d2029d3879fa4991d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->