### PR TITLE
Upgrade Fern

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "4.68.4"
+  "version": "5.65.3"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -3,7 +3,7 @@ groups:
   local:
     generators:
       - name: fernapi/fern-go-sdk
-        version: 1.34.5
+        version: 1.46.4
         config:
           importPath: github.com/Method-Security/osintscan/generated/go
         output:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only version bumps with no application logic changes; main follow-up is regenerating SDK output and fixing any compile breaks from codegen differences.
> 
> **Overview**
> Bumps the **Fern CLI** in `fern/fern.config.json` from **4.68.4** to **5.65.3** and the **local Go SDK generator** (`fernapi/fern-go-sdk`) in `fern/generators.yml` from **1.34.5** to **1.46.4**. The **pypi-local** Pydantic generator version is unchanged.
> 
> After merge, run `fern generate --group local` (and regenerate Python if you rely on matching outputs) so `generated/go` stays aligned with the new toolchain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a4567c0be6a19109ff3d512d88c88043bb46c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->