### PR TITLE
Active DNS: Add List Randomization Functionality

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -27,8 +27,6 @@ import (
 	shodan "github.com/Method-Security/osintscan/internal/discover/shodan"
 	"github.com/spf13/cobra"
 
-	// Configs
-	"github.com/Method-Security/osintscan/configs"
 	// Utils
 	"github.com/Method-Security/osintscan/utils"
 )
@@ -327,6 +325,11 @@ func (a *OsintScan) InitDiscoverCommand() {
 				a.OutputSignal.AddError(err)
 				return
 			}
+			randomizeList, err := cmd.Flags().GetBool("randomize-list")
+			if err != nil {
+				a.OutputSignal.AddError(err)
+				return
+			}
 
 			var wordlistSubdomains []string
 			var wordlistSizeEnum *dnsfern.WordlistSize
@@ -347,13 +350,10 @@ func (a *OsintScan) InitDiscoverCommand() {
 				}
 				wordlistSizeEnum = &wordlistSizeEnumValue
 
-				embeddedPath := subdomain.GetDiscoverDNSSubdomainActiveWordlistEmbeddedPath(wordlistSize)
-				if embeddedPath != "" {
-					wordlistSubdomains, err = configs.ReadLines(embeddedPath)
-					if err != nil {
-						a.OutputSignal.AddError(err)
-						return
-					}
+				wordlistSubdomains, err = subdomain.GetDiscoverDNSSubdomainActiveWordlist(wordlistSize, randomizeList)
+				if err != nil {
+					a.OutputSignal.AddError(err)
+					return
 				}
 			}
 			allSubdomains := append(subdomains, wordlistSubdomains...)
@@ -399,7 +399,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 					return
 				}
 			}
-			config := getDiscoverDNSActiveSubdomainConfig(domain, wordlistSizeEnum, &wordlistFile, threads, maxDepth, timeout, sleep, wildcardChecks, dnsResolvers)
+			config := getDiscoverDNSActiveSubdomainConfig(domain, wordlistSizeEnum, &wordlistFile, randomizeList, threads, maxDepth, timeout, sleep, wildcardChecks, dnsResolvers)
 
 			report, err := subdomain.GetDomainSubdomainsActive(cmd.Context(), allSubdomains, config)
 			if err != nil {
@@ -417,6 +417,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 	discoverDNSSubdomainActiveCmd.Flags().StringSlice("subdomains", []string{}, "A list of subdomain names to test during discovery")
 	discoverDNSSubdomainActiveCmd.Flags().String("wordlist-size", "SMALL", "The size of the in-built wordlist to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().String("wordlist-file", "", "The file containing the wordlist to use for discovery")
+	discoverDNSSubdomainActiveCmd.Flags().Bool("randomize-list", false, "Select random entries from the largest in-built wordlist while preserving the requested wordlist size")
 	discoverDNSSubdomainActiveCmd.Flags().Int("threads", 100, "Number of parallel threads to use for discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("max-depth", 1, "Maximum recursion depth for subdomain discovery")
 	discoverDNSSubdomainActiveCmd.Flags().Int("timeout", 65, "Maximum time (in minutes) to spend on subdomain discovery")
@@ -955,13 +956,14 @@ func getDiscoverDNSReverseConfig(ips []string, cidr string, dnsResolvers []strin
 }
 
 // getDiscoverDNSActiveSubdomainConfig creates and returns a configuration for active subdomain discovery
-func getDiscoverDNSActiveSubdomainConfig(domain string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, threads, maxDepth, timeout, sleep, wildcardChecks int, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
+func getDiscoverDNSActiveSubdomainConfig(domain string, wordlistSize *dnsfern.WordlistSize, wordlistFile *string, randomizeList bool, threads, maxDepth, timeout, sleep, wildcardChecks int, dnsResolvers []string) dnsfern.DiscoverDnsSubdomainConfig {
 	return dnsfern.DiscoverDnsSubdomainConfig{
 		DiscoveryType: strings.ToLower(string(dnsfern.DiscoverDnsSubdomainTypeActive)),
 		Active: &dnsfern.DiscoverDnsSubdomainActiveConfig{
 			Domain:         domain,
 			WordlistSize:   wordlistSize,
 			WordlistFile:   wordlistFile,
+			RandomizeList:  randomizeList,
 			Threads:        threads,
 			MaxDepth:       maxDepth,
 			Timeout:        timeout,

--- a/fern/definition/discover/dns/subdomain.yml
+++ b/fern/definition/discover/dns/subdomain.yml
@@ -22,6 +22,7 @@ types:
       domain: string
       wordlistSize: optional<WordlistSize>
       wordlistFile: optional<string>
+      randomizeList: boolean
       threads: integer
       maxDepth: integer
       timeout: integer

--- a/internal/discover/dns/subdomain/active.go
+++ b/internal/discover/dns/subdomain/active.go
@@ -2,7 +2,9 @@ package subdomain
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
+	"math/big"
 	"net"
 	"sort"
 	"strings"
@@ -12,12 +14,16 @@ import (
 
 	// Generated
 	dnsfern "github.com/Method-Security/osintscan/generated/go/discover/dns"
+	// Configs
+	"github.com/Method-Security/osintscan/configs"
 	// Utils
 	"github.com/Method-Security/osintscan/utils"
 	// External
 	"github.com/miekg/dns"
 	"github.com/palantir/witchcraft-go-logging/wlog/svclog/svc1log"
 )
+
+const largestActiveWordlistSize = "LARGE"
 
 // GetDomainSubdomainsActive performs active (bruteforce) subdomain discovery for a given domain.
 // Returns a report containing all discovered subdomains and any errors encountered.
@@ -368,4 +374,51 @@ func GetDiscoverDNSSubdomainActiveWordlistEmbeddedPath(wordlistSize string) stri
 	}
 
 	return wordlistPaths[wordlistSize]
+}
+
+// GetDiscoverDNSSubdomainActiveWordlist returns the built-in wordlist entries for a requested size.
+// When randomizeList is set, smaller sizes are sampled from the largest built-in list without replacement.
+func GetDiscoverDNSSubdomainActiveWordlist(wordlistSize string, randomizeList bool) ([]string, error) {
+	wordlistPath := GetDiscoverDNSSubdomainActiveWordlistEmbeddedPath(wordlistSize)
+	if wordlistPath == "" {
+		return nil, fmt.Errorf("unsupported active DNS wordlist size %q", wordlistSize)
+	}
+
+	wordlistEntries, err := configs.ReadLines(wordlistPath)
+	if err != nil {
+		return nil, err
+	}
+	if !randomizeList || wordlistSize == largestActiveWordlistSize {
+		return wordlistEntries, nil
+	}
+
+	largestWordlistPath := GetDiscoverDNSSubdomainActiveWordlistEmbeddedPath(largestActiveWordlistSize)
+	largestWordlistEntries, err := configs.ReadLines(largestWordlistPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return selectRandomEntries(largestWordlistEntries, len(wordlistEntries))
+}
+
+func selectRandomEntries(entries []string, count int) ([]string, error) {
+	if count < 0 || count > len(entries) {
+		return nil, fmt.Errorf("cannot select %d entries from list of size %d", count, len(entries))
+	}
+	if count == len(entries) {
+		return append([]string(nil), entries...), nil
+	}
+
+	shuffledEntries := append([]string(nil), entries...)
+	for i := 0; i < count; i++ {
+		remaining := len(shuffledEntries) - i
+		randomOffset, err := rand.Int(rand.Reader, big.NewInt(int64(remaining)))
+		if err != nil {
+			return nil, fmt.Errorf("failed to select random wordlist entry: %w", err)
+		}
+		randomIndex := i + int(randomOffset.Int64())
+		shuffledEntries[i], shuffledEntries[randomIndex] = shuffledEntries[randomIndex], shuffledEntries[i]
+	}
+
+	return shuffledEntries[:count], nil
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optional discovery flag with default off; changes only how built-in wordlists are chosen, not auth or data handling.
> 
> **Overview**
> Adds optional **`--randomize-list`** to active subdomain discovery so built-in wordlists can vary between runs while keeping the same **wordlist size** (TINY/SMALL/MEDIUM/LARGE).
> 
> When enabled (and size is not **LARGE**), the CLI no longer uses the fixed embedded list for that tier; it loads the **LARGE** wordlist and **randomly samples** the same number of entries as the tier would normally use, without replacement (`crypto/rand` via `selectRandomEntries` in `GetDiscoverDNSSubdomainActiveWordlist`). Wordlist loading is centralized in the subdomain package instead of `configs.ReadLines` in `cmd/discover.go`.
> 
> The Fern **`DiscoverDnsSubdomainActiveConfig`** gains **`randomizeList`**, wired through **`getDiscoverDNSActiveSubdomainConfig`** for API/MCP callers. Custom **`--wordlist-file`** behavior is unchanged; randomization applies only to built-in sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2419a259c51dfdfb284e58c508f0748322887ff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->