### PR TITLE
Fix release version injection and ARM Linux snapshot builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: goreleaser-pro
           version: "~> v2.15"
           args: >-
-            build --single-target --clean --snapshot --timeout 60m
+            build --single-target --timeout 60m
             -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser/goreleaser-build.yml
+++ b/.goreleaser/goreleaser-build.yml
@@ -12,7 +12,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static -lm -ldl -lpthread'"
-      - -X github.com/method-security/osintscan/main.version={{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -27,7 +27,7 @@ builds:
     binary: osintscan
     ldflags:
       - -s -w
-      - -X github.com/method-security/osintscan/main.version={{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:
@@ -41,7 +41,7 @@ builds:
     binary: osintscan
     ldflags:
       - -s -w
-      - -X github.com/method-security/osintscan/main.version={{.Version}}
+      - -X main.version={{.Version}}
     env:
       - CGO_ENABLED=1
     goos:


### PR DESCRIPTION
Two release-path defects, both invisible to PR CI because `test-build.yml` runs `goreleaser build` and never `release` — so neither shows up until a tag is pushed. Same fix as [networkscan#342](https://github.com/method-security/networkscan/pull/342); every Method Go CLI shares the first one.

---

## 1. The version ldflag has never applied

The builds set `-X github.com/method-security/osintscan/main.version={{.Version}}`. That symbol path matches neither the module path — `github.com/Method-Security/osintscan`, capitalised — nor the `main` package, which sits at the module root and so has no `/main` segment. The Go linker silently ignores `-X` for a symbol it can't resolve, so the injection is a no-op.

This is not theoretical. Running the **shipped release binaries**:

```
$ ./osintscan version     # from osintscan v0.0.101 macOS-ARM64
none
$ ./networkscan version   # from networkscan v0.1.2 macOS-ARM64
none
```

Both should print their tag. Confirmed the mechanism directly by building a sibling repo both ways:

```
$ go build -ldflags "-X github.com/method-security/networkscan/main.version=TESTVER" .
$ ./networkscan version
none
$ go build -ldflags "-X main.version=TESTVER2" .
$ ./networkscan version
TESTVER2
```

Switched to `-X main.version={{.Version}}`, the conventional form for a root `main` package.

## 2. The ARM Linux build is forced into snapshot mode on releases

`prepare-linux-arm` hardcoded `--clean --snapshot` *in addition to* passing `${{ inputs.goreleaser_options }}`:

```yaml
args: >-
  build --single-target --clean --snapshot --timeout 60m
  -f .goreleaser/goreleaser-build.yml ${{ inputs.goreleaser_options }}
```

On a tagged release `release.yml` supplies `goreleaser_options: "--clean"`, so the ARM64 Linux binary is built in snapshot mode while the `prepare` matrix — which passes inputs through unmodified — uses the real tag. Even once (1) is fixed, ARM64 Linux would report a *different* version than every other artifact in the same release.

Now passes inputs through the same way, keeping `--timeout 60m`. The PR path is unaffected: `test-build.yml` already supplies `--clean --snapshot` explicitly, so snapshot behaviour there is unchanged.

---

## Verification

The ldflag mechanism is proven by the commands above. The `--snapshot` change is config-only and can't be exercised without pushing a tag — the argument is the flag precedence described above, and PR builds keep their existing `--clean --snapshot`.

Worth confirming on the next release that `version` returns the tag rather than `none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release and CI build configuration only; no runtime logic changes beyond correct version stamping at link time.
> 
> **Overview**
> Fixes **release binaries reporting `none` for `version`** and **linux/arm64 artifacts using snapshot versioning on tagged releases**.
> 
> GoReleaser **ldflags** now inject the tag with `-X main.version={{.Version}}` instead of a non-resolving `github.com/method-security/osintscan/main.version` path, so the root `main` package’s `version` variable is actually set at link time.
> 
> The **linux arm64** reusable job no longer hardcodes `--clean --snapshot` on `goreleaser build`; it only keeps `--single-target --timeout 60m` and forwards `${{ inputs.goreleaser_options }}`, matching other prepare jobs so release workflows can supply the real tag instead of forcing snapshot mode for that artifact only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a2ee0a928dfe3b5d2bafef248f474a8facf3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->