### PR TITLE
Fix wrong flag name in ip-addresses/cidr error messages

### DIFF
--- a/cmd/discover.go
+++ b/cmd/discover.go
@@ -251,7 +251,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 				return
 			}
 			if len(ips) == 0 && cidr == "" {
-				a.OutputSignal.AddError(fmt.Errorf("either --ips or --cidr must be provided"))
+				a.OutputSignal.AddError(fmt.Errorf("either --ip-addresses or --cidr must be provided"))
 				return
 			}
 
@@ -851,7 +851,7 @@ func (a *OsintScan) InitDiscoverCommand() {
 
 			// Validate that either ip or cidr is provided
 			if len(ips) == 0 && cidr == "" {
-				a.OutputSignal.AddError(fmt.Errorf("either --ips or --cidr must be provided"))
+				a.OutputSignal.AddError(fmt.Errorf("either --ip-addresses or --cidr must be provided"))
 				return
 			}
 


### PR DESCRIPTION
The reverse DNS and IP/domain ASN commands referenced --ips in their validation error, but the flag is registered as --ip-addresses.

Fixes #165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to two error messages; no behavior or validation logic changes.
> 
> **Overview**
> Updates validation error text when neither IPs nor CIDR are supplied on **`discover dns reverse`** and **`discover ip domain-asn`**, replacing the incorrect **`--ips`** reference with **`--ip-addresses`** to match the registered flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a727ac9253eb70e214ab17f44d38c13964b8018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->