### PR TITLE
Have CI install the latest Go 1.26.x patch instead of a pinned patch

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -13,7 +13,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26"
 
 jobs:
   prepare-linux-arm:
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
       - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # ratchet:goreleaser/goreleaser-action@v7
         with:
@@ -146,6 +147,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # ratchet:goreleaser/goreleaser-action@v7
@@ -223,6 +225,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache: true
 
       - name: Download Artifacts

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26"
+          check-latest: true
           cache: true
 
       - name: Godel Verify


### PR DESCRIPTION
Use a fuzzy go-version (1.26) with check-latest in reusable-build.yml and verify.yml so builds always pick up the newest 1.26 patch release, while go.mod keeps pinning an exact minimum version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only Go toolchain selection with no application or dependency logic changes.
> 
> **Overview**
> CI no longer pins **Go 1.26.5**; **`reusable-build.yml`** and **`verify.yml`** now use **`go-version: "1.26"`** (or **`GO_VERSION: "1.26"`**) with **`check-latest: true`** on every **`actions/setup-go`** step so runners install the newest **1.26** patch automatically.
> 
> **`go.mod`** is unchanged and still defines the exact minimum Go version for the module; only workflow toolchain selection is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0346395128b6fd0f925f8ee9886211a20b7f57b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->